### PR TITLE
Implement ver stage

### DIFF
--- a/src/frida_data.rs
+++ b/src/frida_data.rs
@@ -61,14 +61,6 @@ pub fn build_evaluations_from_data<E: FieldElement>(
     let mut symbols: Vec<E> = data_to_field_element(&encoded_data, domain_size)?;
     symbols.resize(domain_size / blowup_factor, E::default());
 
-    // let inv_twiddles = fft::get_inv_twiddles(symbols.len());
-    // fft::interpolate_poly(&mut symbols, &inv_twiddles);
-
-    // symbols.resize(domain_size, E::default());
-    // let twiddles = fft::get_twiddles(domain_size);
-    // fft::evaluate_poly(&mut symbols, &twiddles);
-
-    // Ok(symbols)
     Ok(reed_solomon_encode_data(
         &symbols,
         domain_size / blowup_factor,

--- a/src/frida_data.rs
+++ b/src/frida_data.rs
@@ -82,7 +82,7 @@ pub fn reed_solomon_encode_data<E: FieldElement>(
     let twiddles = fft::get_twiddles(domain_size);
     fft::evaluate_poly(&mut coeffs, &twiddles);
 
-    coeffs // coeffs is not the evaluation points
+    coeffs // coeffs is now the evaluation points
 }
 
 fn reconstruct_evaluations<E: FieldElement>(

--- a/src/frida_error.rs
+++ b/src/frida_error.rs
@@ -9,4 +9,7 @@ pub enum FridaError {
     FailedToDrawEnoughQueryPoints(usize, usize),
     DomainSizeTooBig(usize),
     BadNumQueries(usize),
+    InvalidDASCommitment,
+    /// Polynomial degree at one of the FRI layers could not be divided evenly by the folding factor.
+    DegreeTruncation(usize, usize, usize),
 }

--- a/src/frida_error.rs
+++ b/src/frida_error.rs
@@ -10,6 +10,7 @@ pub enum FridaError {
     DomainSizeTooBig(usize),
     BadNumQueries(usize),
     InvalidDASCommitment,
+    FailToVerify,
     /// Polynomial degree at one of the FRI layers could not be divided evenly by the folding factor.
     DegreeTruncation(usize, usize, usize),
 }

--- a/src/frida_error.rs
+++ b/src/frida_error.rs
@@ -13,4 +13,5 @@ pub enum FridaError {
     FailToVerify,
     /// Polynomial degree at one of the FRI layers could not be divided evenly by the folding factor.
     DegreeTruncation(usize, usize, usize),
+    UnsupportedFoldingFactor(usize),
 }

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -136,6 +136,7 @@ where
         }
 
         let evaluations = build_evaluations_from_data(&data, domain_size, blowup_factor)?;
+        println!("evaluations in build_layers_from_data: {:?}", evaluations);
 
         if num_queries == 0 {
             let mut channel = C::new(domain_size, 1);
@@ -175,6 +176,7 @@ where
     fn query(&mut self) -> FridaProof {
         if let Some(channel) = &mut self.channel {
             let query_positions = channel.draw_query_positions();
+            // let query_positions = vec![1];
             self.build_proof(&query_positions)
         } else {
             panic!("Channel does not exist")

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -42,6 +42,7 @@ pub struct FridaRemainder<E: FieldElement>(Vec<E>);
 pub struct Commitment<HRoot: ElementHasher> {
     pub roots: Vec<HRoot::Digest>,
     pub proof: FridaProof,
+    pub num_queries: usize,
 }
 
 // PROVER IMPLEMENTATION
@@ -165,6 +166,7 @@ where
         let commitment = Commitment {
             roots: channel.take_layer_commitments(),
             proof,
+            num_queries,
         };
 
         Ok((commitment, data))
@@ -247,7 +249,8 @@ mod tests {
         prover.reset();
 
         let data = rand_vector::<u8>(200);
-        let (commitment, state) = prover.commit(data.clone(), 31).unwrap();
+        let num_queries: usize = 31;
+        let (commitment, state) = prover.commit(data.clone(), num_queries).unwrap();
 
         let evaluations = build_evaluations_from_data(&data, 32, 2).unwrap();
         let mut prover = FridaProver::new(options.clone());
@@ -256,7 +259,7 @@ mod tests {
             Blake3_256<BaseElement>,
             Blake3_256<BaseElement>,
             FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
-        >::new(32, 31);
+        >::new(32, num_queries);
         prover.build_layers(&mut channel, evaluations.clone());
         let positions = channel.draw_query_positions();
         let proof = prover.build_proof(&positions);
@@ -265,7 +268,8 @@ mod tests {
             commitment,
             Commitment {
                 roots: channel.layer_commitments().to_vec(),
-                proof: proof
+                proof: proof,
+                num_queries
             }
         );
         assert_eq!(state, data);

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -136,7 +136,6 @@ where
         }
 
         let evaluations = build_evaluations_from_data(&data, domain_size, blowup_factor)?;
-        println!("evaluations in build_layers_from_data: {:?}", evaluations);
 
         if num_queries == 0 {
             let mut channel = C::new(domain_size, 1);
@@ -176,7 +175,6 @@ where
     fn query(&mut self) -> FridaProof {
         if let Some(channel) = &mut self.channel {
             let query_positions = channel.draw_query_positions();
-            // let query_positions = vec![1];
             self.build_proof(&query_positions)
         } else {
             panic!("Channel does not exist")

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -124,7 +124,7 @@ where
         let encoded_element_count = encoded_data_element_count::<E>(data.len());
 
         let domain_size = usize::max(
-            (encoded_element_count * blowup_factor).next_power_of_two(),
+            encoded_element_count.next_power_of_two() * blowup_factor,
             frida_const::MIN_DOMAIN_SIZE,
         );
 

--- a/src/frida_prover/proof.rs
+++ b/src/frida_prover/proof.rs
@@ -130,14 +130,14 @@ impl FridaProof {
     /// * This proof is not consistent with the specified `domain_size` and `folding_factor`.
     /// * Any of the layers could not be parsed successfully.
     #[allow(clippy::type_complexity)]
-    pub fn parse_layers<H, E>(
+    pub fn parse_layers<HRandom, E>(
         self,
         mut domain_size: usize,
         folding_factor: usize,
-    ) -> Result<(Vec<Vec<E>>, Vec<BatchMerkleProof<H>>), DeserializationError>
+    ) -> Result<(Vec<Vec<E>>, Vec<BatchMerkleProof<HRandom>>), DeserializationError>
     where
         E: FieldElement,
-        H: ElementHasher<BaseField = E::BaseField>,
+        HRandom: ElementHasher<BaseField = E::BaseField>,
     {
         assert!(
             domain_size.is_power_of_two(),

--- a/src/frida_prover/traits.rs
+++ b/src/frida_prover/traits.rs
@@ -66,15 +66,8 @@ where
         // rows of this matrix; we do this so that we could de-commit to N values with a single
         // Merkle authentication path.
         let transposed_evaluations = transpose_slice(evaluations);
-        println!(
-            "transposed_evaluations in build_layer: {:?}",
-            transposed_evaluations
-        );
         let hashed_evaluations = hash_values::<H, E, N>(&transposed_evaluations);
-        println!(
-            "hashed_evaluations in build_layer: {:?}",
-            hashed_evaluations
-        );
+
         let evaluation_tree =
             MerkleTree::<H>::new(hashed_evaluations).expect("failed to construct FRI layer tree");
         channel.commit_fri_layer(*evaluation_tree.root());
@@ -114,7 +107,6 @@ where
 
         let layers_len = self.num_layers();
         let mut layers = Vec::with_capacity(layers_len);
-        println!("positions in build_proof: {:?}", positions);
 
         if layers_len != 0 {
             let mut positions = positions.to_vec();
@@ -157,7 +149,6 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
     positions: &[usize],
 ) -> FridaProofLayer {
     // build Merkle authentication paths for all query positions
-    println!("positions in query_layer: {:?}", positions);
     let proof = layer
         .tree
         .prove_batch(positions)
@@ -167,16 +158,10 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
     // are stored in transposed form, a position refers to N evaluations which are committed
     // in a single leaf
     let evaluations: &[[E; N]] = group_slice_elements(&layer.evaluations);
-    println!("evaluations in query_layer: {:?}", evaluations);
-    println!(
-        "flattened evaluations in query_layer: {:?}",
-        flatten_vector_elements(evaluations.to_vec())
-    );
     let mut queried_values: Vec<[E; N]> = Vec::with_capacity(positions.len());
     for &position in positions.iter() {
         queried_values.push(evaluations[position]);
     }
 
-    println!("queried_values in query_layer: {:?}", queried_values);
     FridaProofLayer::new(queried_values, proof)
 }

--- a/src/frida_prover/traits.rs
+++ b/src/frida_prover/traits.rs
@@ -66,7 +66,15 @@ where
         // rows of this matrix; we do this so that we could de-commit to N values with a single
         // Merkle authentication path.
         let transposed_evaluations = transpose_slice(evaluations);
+        println!(
+            "transposed_evaluations in build_layer: {:?}",
+            transposed_evaluations
+        );
         let hashed_evaluations = hash_values::<H, E, N>(&transposed_evaluations);
+        println!(
+            "hashed_evaluations in build_layer: {:?}",
+            hashed_evaluations
+        );
         let evaluation_tree =
             MerkleTree::<H>::new(hashed_evaluations).expect("failed to construct FRI layer tree");
         channel.commit_fri_layer(*evaluation_tree.root());
@@ -106,6 +114,7 @@ where
 
         let layers_len = self.num_layers();
         let mut layers = Vec::with_capacity(layers_len);
+        println!("positions in build_proof: {:?}", positions);
 
         if layers_len != 0 {
             let mut positions = positions.to_vec();
@@ -148,6 +157,7 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
     positions: &[usize],
 ) -> FridaProofLayer {
     // build Merkle authentication paths for all query positions
+    println!("positions in query_layer: {:?}", positions);
     let proof = layer
         .tree
         .prove_batch(positions)
@@ -157,10 +167,16 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
     // are stored in transposed form, a position refers to N evaluations which are committed
     // in a single leaf
     let evaluations: &[[E; N]] = group_slice_elements(&layer.evaluations);
+    println!("evaluations in query_layer: {:?}", evaluations);
+    println!(
+        "flattened evaluations in query_layer: {:?}",
+        flatten_vector_elements(evaluations.to_vec())
+    );
     let mut queried_values: Vec<[E; N]> = Vec::with_capacity(positions.len());
     for &position in positions.iter() {
         queried_values.push(evaluations[position]);
     }
 
+    println!("queried_values in query_layer: {:?}", queried_values);
     FridaProofLayer::new(queried_values, proof)
 }

--- a/src/frida_verifier/das.rs
+++ b/src/frida_verifier/das.rs
@@ -14,7 +14,7 @@ use crate::{
     frida_verifier_channel::FridaVerifierChannel,
 };
 
-use super::verifier2::FridaVerifier2;
+use super::verifier::FridaVerifier;
 
 pub struct FridaDasVerifier<E, HHst, HRandom, R>
 where
@@ -46,18 +46,17 @@ where
         HashRandom = HRandom,
     >,
 {
+    /**
+     * Accepts DAS commitment as input
+     * Will perform verification on correctness of folding
+     */
     pub fn new(
         das_commitment: Commitment<HRandom>,
         public_coin: &mut R,
         options: FriOptions,
         max_poly_degree: usize,
     ) -> Result<Self, FridaError> {
-        // accepts das commitment as input
-        // store layer_commitments
-        // compute and store layered alpha
-        // infer evaluation domain info
         let domain_size = max_poly_degree.next_power_of_two() * options.blowup_factor();
-
         let num_partitions = das_commitment.proof.num_partitions();
 
         // read layer commitments from the channel and use them to build a list of alphas
@@ -84,103 +83,76 @@ where
             max_degree_plus_1 /= options.folding_factor();
         }
 
-        // double check if the hst used here is correct as 'stored layered alpha'
-        // above seems to have made an 'extra' round of alpha query
-        // draw_query_positions from FridaRandom for x num of queries
-        // to get the openings for checking of folding for correctness
         let positions =
             public_coin.draw_query_positions(das_commitment.num_queries, domain_size)?;
-        println!("positions in verifier::new(): {:?}", positions);
 
-        let folded_positions = fold_positions(&positions, domain_size, options.folding_factor());
+        // get query value from commitment
+        let query_values = {
+            let folded_positions =
+                fold_positions(&positions, domain_size, options.folding_factor());
 
-        println!(
-            "folded_positions in verifier::new(): {:?}",
-            folded_positions
-        );
-        // let positions = vec![1];
-
-        // verify commitment is correct by using CheckAuth
-        // * to modify FridaVerifier to accept 'layer_commitments' and 'layered_alpha' in 'new', else it needs to recalculate
-        // * this value every time
-        // * actually i think we can move the entire 'new' function here
-
-        // if CheckAuth for any of the opening fails, we will return Error in 'new' function
-        // note that our FridaProof has batched multiple positions into one proof
-
-        // perform verify
-        // i think its ok to recreate FridaVerifierChannel everytime
-
-        let frida_verifier = FridaVerifier2::<E, HRandom>::new(
-            layer_commitments.clone(),
-            layer_alphas.clone(),
-            num_partitions,
-            options.clone(),
-            max_poly_degree,
-        )
-        .map_err(|_e| FridaError::InvalidDASCommitment)?;
-
-        let (queried_layers, _) = das_commitment
-            .proof
-            .clone()
-            .parse_layers::<HRandom, E>(domain_size.clone(), options.folding_factor())
+            let mut verifier_channel = FridaVerifierChannel::<E, HRandom>::new(
+                das_commitment.proof.clone(),
+                layer_commitments.clone(),
+                domain_size.clone(),
+                options.folding_factor(),
+            )
             .map_err(|_e| FridaError::InvalidDASCommitment)?;
+            let position_indexes = map_positions_to_indexes(
+                &folded_positions,
+                domain_size,
+                options.folding_factor(),
+                num_partitions,
+            );
+            let layer_commitment = layer_commitments[0];
+            let layer_values = verifier_channel
+                .read_layer_queries(&position_indexes, &layer_commitment)
+                .unwrap();
 
-        println!("queried_layers in verifier::new(): {:?}", queried_layers);
-        let evaluations = queried_layers
-            .first()
-            .ok_or(FridaError::InvalidDASCommitment)?
-            .to_owned();
-        println!("evaluations in verifier::new(): {:?}", evaluations);
-
-        // let query_values =
-        //         get_query_values::<E, N>(&layer_values, &positions, &folded_positions, domain_size);
-        // let actual_evaluation = get_query_values2(
-        //     queried_layers.clone(),
-        //     &positions,
-        //     &folded_positions,
-        //     domain_size,
-        // );
-
-        let mut verifier_channel = FridaVerifierChannel::<E, HRandom>::new(
-            das_commitment.proof.clone(),
-            layer_commitments.clone(),
-            domain_size.clone(),
-            options.folding_factor(),
-        )
-        .map_err(|_e| FridaError::InvalidDASCommitment)?;
-
-        //       // determine which evaluations were queried in the folded layer
-        //       let mut folded_positions =
-        //       fold_positions(&positions, domain_size, self.options.folding_factor());
-        //   // determine where these evaluations are in the commitment Merkle tree
-        let position_indexes = map_positions_to_indexes(
-            &folded_positions,
-            domain_size,
-            options.folding_factor(),
-            num_partitions,
-        );
-        let layer_commitment = layer_commitments[0];
-        let layer_values = verifier_channel
-            .read_layer_queries(&position_indexes, &layer_commitment)
-            .unwrap();
-        let query_values =
-            get_query_values::<E, 2>(&layer_values, &positions, &folded_positions, domain_size);
-        //   if evaluations != query_values {
-        //       return Err(VerifierError::InvalidLayerFolding(depth));
-        //   }
-        // verifier_channel.take_next_fri_layer_queries();
-
-        // let layer_values =
-        //     verifier_channel.read_layer_queries(&position_indexes, &layer_commitment)?;
-
-        println!("query_values in verifier::new(): {:?}", query_values);
+            let folding_factor = options.folding_factor();
+            match folding_factor {
+                2 => Ok(get_query_values::<E, 2>(
+                    &layer_values,
+                    &positions,
+                    &folded_positions,
+                    domain_size,
+                )),
+                4 => Ok(get_query_values::<E, 2>(
+                    &layer_values,
+                    &positions,
+                    &folded_positions,
+                    domain_size,
+                )),
+                8 => Ok(get_query_values::<E, 2>(
+                    &layer_values,
+                    &positions,
+                    &folded_positions,
+                    domain_size,
+                )),
+                16 => Ok(get_query_values::<E, 2>(
+                    &layer_values,
+                    &positions,
+                    &folded_positions,
+                    domain_size,
+                )),
+                _ => Err(FridaError::UnsupportedFoldingFactor(folding_factor)),
+            }?
+        };
 
         let mut verifier_channel = FridaVerifierChannel::<E, HRandom>::new(
             das_commitment.proof,
             layer_commitments.clone(),
             domain_size.clone(),
             options.folding_factor(),
+        )
+        .map_err(|_e| FridaError::InvalidDASCommitment)?;
+
+        let frida_verifier = FridaVerifier::<E, HRandom>::new(
+            layer_commitments.clone(),
+            layer_alphas.clone(),
+            num_partitions,
+            options.clone(),
+            max_poly_degree,
         )
         .map_err(|_e| FridaError::InvalidDASCommitment)?;
 
@@ -215,7 +187,7 @@ where
         )
         .map_err(|_e| FridaError::DeserializationError())?;
 
-        let frida_verifier = FridaVerifier2::<E, HRandom>::new(
+        let frida_verifier = FridaVerifier::<E, HRandom>::new(
             self.layer_commitments.clone(),
             self.layer_alphas.clone(),
             self.num_partitions,
@@ -227,101 +199,5 @@ where
         frida_verifier
             .check_auth(&mut verifier_channel, &evaluations, &positions)
             .map_err(|_e| FridaError::FailToVerify)
-    }
-}
-
-fn get_query_values2<E: FieldElement>(
-    values: Vec<Vec<E>>,
-    positions: &[usize],
-    folded_positions: &[usize],
-    domain_size: usize,
-) -> Vec<E> {
-    let length = values.first().unwrap().len();
-    let row_length = domain_size / length;
-
-    let mut result = Vec::new();
-    for position in positions {
-        let idx = folded_positions
-            .iter()
-            .position(|&v| v == position % row_length)
-            .unwrap();
-        let value = values[idx][position / row_length];
-        result.push(value);
-    }
-
-    result
-}
-#[cfg(test)]
-mod test {
-    use winter_crypto::hashers::Blake3_256;
-    use winter_fri::FriOptions;
-    use winter_math::fields::f128::BaseElement;
-    use winter_rand_utils::rand_vector;
-
-    use crate::{
-        frida_data::{build_evaluations_from_data, encoded_data_element_count},
-        frida_prover::{traits::BaseFriProver, FridaProver},
-        frida_prover_channel::FridaProverChannel,
-        frida_random::{FridaRandom, FridaRandomCoin},
-    };
-
-    use super::FridaDasVerifier;
-
-    #[test]
-    fn test_frida_das_verify() {
-        let lde_blowup_e = 3;
-        let folding_factor_e = 1;
-        let max_remainder_degree = 7;
-        let lde_blowup = 1 << lde_blowup_e;
-        let folding_factor = 1 << folding_factor_e;
-
-        let options = FriOptions::new(lde_blowup, folding_factor, max_remainder_degree);
-
-        // instantiate the prover and generate the proof
-        let mut prover: FridaProver<
-            BaseElement,
-            BaseElement,
-            FridaProverChannel<
-                BaseElement,
-                Blake3_256<BaseElement>,
-                Blake3_256<BaseElement>,
-                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
-            >,
-            Blake3_256<BaseElement>,
-        > = FridaProver::new(options.clone());
-
-        let data = rand_vector::<u8>(200);
-        let (commitment, _) = prover.commit(data.clone(), 31).unwrap();
-
-        let mut public_coin =
-            FridaRandom::<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>::new(&[
-                123,
-            ]);
-
-        let encoded_element_count = encoded_data_element_count::<BaseElement>(data.len());
-
-        let verifier = FridaDasVerifier::new(
-            commitment,
-            &mut public_coin,
-            options.clone(),
-            encoded_element_count - 1,
-        )
-        .unwrap();
-
-        // query for a position
-        let open_position = [1];
-        let proof = prover.open(&open_position);
-
-        let domain_size = (encoded_element_count - 1).next_power_of_two() * options.blowup_factor();
-        let evaluations: Vec<BaseElement> =
-            build_evaluations_from_data(&data, domain_size, options.blowup_factor()).unwrap();
-
-        let queried_evaluations = open_position
-            .iter()
-            .map(|&p| evaluations[p])
-            .collect::<Vec<_>>();
-        let result = verifier.verify(proof, &queried_evaluations, &open_position);
-
-        assert!(result.is_ok(), "{:?}", result.err().unwrap());
     }
 }

--- a/src/frida_verifier/das.rs
+++ b/src/frida_verifier/das.rs
@@ -105,36 +105,53 @@ where
                 num_partitions,
             );
             let layer_commitment = layer_commitments[0];
-            let layer_values = verifier_channel
-                .read_layer_queries(&position_indexes, &layer_commitment)
-                .unwrap();
 
             let folding_factor = options.folding_factor();
             match folding_factor {
-                2 => Ok(get_query_values::<E, 2>(
-                    &layer_values,
-                    &positions,
-                    &folded_positions,
-                    domain_size,
-                )),
-                4 => Ok(get_query_values::<E, 2>(
-                    &layer_values,
-                    &positions,
-                    &folded_positions,
-                    domain_size,
-                )),
-                8 => Ok(get_query_values::<E, 2>(
-                    &layer_values,
-                    &positions,
-                    &folded_positions,
-                    domain_size,
-                )),
-                16 => Ok(get_query_values::<E, 2>(
-                    &layer_values,
-                    &positions,
-                    &folded_positions,
-                    domain_size,
-                )),
+                2 => {
+                    let layer_values = verifier_channel
+                        .read_layer_queries(&position_indexes, &layer_commitment)
+                        .unwrap();
+                    Ok(get_query_values::<E, 2>(
+                        &layer_values,
+                        &positions,
+                        &folded_positions,
+                        domain_size,
+                    ))
+                }
+                4 => {
+                    let layer_values = verifier_channel
+                        .read_layer_queries(&position_indexes, &layer_commitment)
+                        .unwrap();
+                    Ok(get_query_values::<E, 4>(
+                        &layer_values,
+                        &positions,
+                        &folded_positions,
+                        domain_size,
+                    ))
+                }
+                8 => {
+                    let layer_values = verifier_channel
+                        .read_layer_queries(&position_indexes, &layer_commitment)
+                        .unwrap();
+                    Ok(get_query_values::<E, 8>(
+                        &layer_values,
+                        &positions,
+                        &folded_positions,
+                        domain_size,
+                    ))
+                }
+                16 => {
+                    let layer_values = verifier_channel
+                        .read_layer_queries(&position_indexes, &layer_commitment)
+                        .unwrap();
+                    Ok(get_query_values::<E, 16>(
+                        &layer_values,
+                        &positions,
+                        &folded_positions,
+                        domain_size,
+                    ))
+                }
                 _ => Err(FridaError::UnsupportedFoldingFactor(folding_factor)),
             }?
         };

--- a/src/frida_verifier/das.rs
+++ b/src/frida_verifier/das.rs
@@ -1,0 +1,155 @@
+use std::marker::PhantomData;
+
+use winter_crypto::{Digest, ElementHasher};
+use winter_fri::FriOptions;
+use winter_math::{FieldElement, StarkField};
+
+use crate::{
+    frida_error::FridaError, frida_prover::Commitment, frida_random::FridaRandomCoin,
+    frida_verifier_channel::FridaVerifierChannel,
+};
+
+use super::verifier2::FridaVerifier2;
+
+pub struct FridaDasVerifier<E, HHst, HRandom, R>
+where
+    E: FieldElement,
+    HHst: ElementHasher<BaseField = E::BaseField>,
+    HRandom: ElementHasher<BaseField = E::BaseField>,
+    R: FridaRandomCoin<BaseField = E::BaseField, HashHst = HHst, HashRandom = HRandom>,
+{
+    max_poly_degree: usize,
+    domain_size: usize,
+    domain_generator: E::BaseField,
+    layer_commitments: Vec<HRandom::Digest>,
+    layer_alphas: Vec<E>,
+    options: FriOptions,
+    num_partitions: usize,
+    _public_coin: PhantomData<R>,
+    _field_element: PhantomData<E>,
+    _h_random: PhantomData<HRandom>,
+}
+
+impl<E, HHst, HRandom, R> FridaDasVerifier<E, HHst, HRandom, R>
+where
+    E: FieldElement,
+    HHst: ElementHasher<BaseField = E::BaseField>,
+    HRandom: ElementHasher<BaseField = E::BaseField>,
+    R: FridaRandomCoin<
+        FieldElement = E,
+        BaseField = E::BaseField,
+        HashHst = HHst,
+        HashRandom = HRandom,
+    >,
+{
+    pub fn new(
+        das_commitment: Commitment<HRandom>,
+        public_coin: &mut R,
+        options: FriOptions,
+        max_poly_degree: usize,
+    ) -> Result<Self, FridaError> {
+        // accepts das commitment as input
+        // store layer_commitments
+        // compute and store layered alpha
+        // infer evaluation domain info
+        let domain_size = max_poly_degree.next_power_of_two() * options.blowup_factor();
+        let domain_generator = E::BaseField::get_root_of_unity(domain_size.ilog2());
+
+        let num_partitions = das_commitment.proof.num_partitions();
+
+        // read layer commitments from the channel and use them to build a list of alphas
+        let layer_commitments = das_commitment.roots;
+        let mut layer_alphas = Vec::with_capacity(layer_commitments.len());
+        let mut max_degree_plus_1 = max_poly_degree + 1;
+        for (depth, commitment) in layer_commitments.iter().enumerate() {
+            public_coin.reseed(&commitment.as_bytes());
+            let alpha = public_coin.draw().map_err(|_e| FridaError::DrawError())?;
+
+            layer_alphas.push(alpha);
+
+            // make sure the degree can be reduced by the folding factor at all layers
+            // but the remainder layer
+            if depth != layer_commitments.len() - 1
+                && max_degree_plus_1 % options.folding_factor() != 0
+            {
+                return Err(FridaError::DegreeTruncation(
+                    max_degree_plus_1 - 1,
+                    options.folding_factor(),
+                    depth,
+                ));
+            }
+            max_degree_plus_1 /= options.folding_factor();
+        }
+
+        // double check if the hst used here is correct as 'stored layered alpha'
+        // above seems to have made an 'extra' round of alpha query
+        // draw_query_positions from FridaRandom for x num of queries
+        // to get the openings for checking of folding for correctness
+        let positions =
+            public_coin.draw_query_positions(das_commitment.num_queries, domain_size)?;
+
+        // verify commitment is correct by using CheckAuth
+        // * to modify FridaVerifier to accept 'layer_commitments' and 'layered_alpha' in 'new', else it needs to recalculate
+        // * this value every time
+        // * actually i think we can move the entire 'new' function here
+
+        // if CheckAuth for any of the opening fails, we will return Error in 'new' function
+        // note that our FridaProof has batched multiple positions into one proof
+
+        // perform verify
+        // i think its ok to recreate FridaVerifierChannel everytime
+
+        let frida_verifier = FridaVerifier2::<E, HRandom>::new(
+            layer_commitments.clone(),
+            layer_alphas.clone(),
+            num_partitions,
+            options.clone(),
+            max_poly_degree,
+        )
+        .map_err(|_e| FridaError::InvalidDASCommitment)?;
+
+        let (queried_layers, _) = das_commitment
+            .proof
+            .clone()
+            .parse_layers::<HRandom, E>(domain_size.clone(), options.folding_factor())
+            .map_err(|_e| FridaError::InvalidDASCommitment)?;
+        let evaluations = queried_layers
+            .first()
+            .ok_or(FridaError::InvalidDASCommitment)?
+            .to_owned();
+
+        let mut verifier_channel = FridaVerifierChannel::<E, HRandom>::new(
+            das_commitment.proof,
+            layer_commitments.clone(),
+            domain_size.clone(),
+            options.folding_factor(),
+        )
+        .map_err(|_e| FridaError::InvalidDASCommitment)?;
+
+        let _ = frida_verifier
+            .check_auth(&mut verifier_channel, &evaluations, &positions)
+            .map_err(|_e| FridaError::InvalidDASCommitment);
+
+        Ok(Self {
+            max_poly_degree,
+            domain_size,
+            num_partitions,
+            layer_commitments,
+            domain_generator,
+            layer_alphas,
+            options,
+            _field_element: PhantomData,
+            _h_random: PhantomData,
+            _public_coin: PhantomData,
+        })
+    }
+
+    pub fn verify(&self) {}
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test_frida_das_verify() {}
+}

--- a/src/frida_verifier/das.rs
+++ b/src/frida_verifier/das.rs
@@ -34,6 +34,7 @@ where
     _h_random: PhantomData<HRandom>,
 }
 
+// TODO: add a base trait for verifier similar to FridaProver
 impl<E, HHst, HRandom, R> FridaDasVerifier<E, HHst, HRandom, R>
 where
     E: FieldElement,

--- a/src/frida_verifier/mod.rs
+++ b/src/frida_verifier/mod.rs
@@ -1,239 +1,9 @@
+use winter_math::FieldElement;
+
 pub mod das;
 mod test;
-mod verifier2;
-
-use std::{marker::PhantomData, mem};
-
-use crate::frida_random::FridaRandomCoin;
-use winter_crypto::{Digest, ElementHasher, RandomCoinError};
-use winter_fri::{
-    folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierChannel,
-    VerifierError,
-};
-use winter_math::{polynom, FieldElement, StarkField};
-
-pub struct FridaVerifier<E, C, HHst, HRandom, R>
-where
-    E: FieldElement,
-    C: VerifierChannel<E, Hasher = HRandom>,
-    HHst: ElementHasher<BaseField = E::BaseField>,
-    HRandom: ElementHasher<BaseField = E::BaseField>,
-    R: FridaRandomCoin<BaseField = E::BaseField, HashHst = HHst, HashRandom = HRandom>,
-{
-    max_poly_degree: usize,
-    domain_size: usize,
-    domain_generator: E::BaseField,
-    layer_commitments: Vec<HRandom::Digest>,
-    layer_alphas: Vec<E>,
-    options: FriOptions,
-    num_partitions: usize,
-    _channel: PhantomData<C>,
-    _public_coin: PhantomData<R>,
-}
-
-impl<E, C, HHst, HRandom, R> FridaVerifier<E, C, HHst, HRandom, R>
-where
-    E: FieldElement,
-    C: VerifierChannel<E, Hasher = HRandom>,
-    HHst: ElementHasher<BaseField = E::BaseField>,
-    HRandom: ElementHasher<BaseField = E::BaseField>,
-    R: FridaRandomCoin<
-        BaseField = E::BaseField,
-        FieldElement = E,
-        HashHst = HHst,
-        HashRandom = HRandom,
-    >,
-{
-    pub fn new(
-        channel: &mut C,
-        public_coin: &mut R,
-        options: FriOptions,
-        max_poly_degree: usize,
-    ) -> Result<Self, VerifierError> {
-        // infer evaluation domain info
-        let domain_size = max_poly_degree.next_power_of_two() * options.blowup_factor();
-        let domain_generator = E::BaseField::get_root_of_unity(domain_size.ilog2());
-
-        let num_partitions = channel.read_fri_num_partitions();
-
-        // read layer commitments from the channel and use them to build a list of alphas
-        let layer_commitments = channel.read_fri_layer_commitments();
-        let mut layer_alphas = Vec::with_capacity(layer_commitments.len());
-        let mut max_degree_plus_1 = max_poly_degree + 1;
-        for (depth, commitment) in layer_commitments.iter().enumerate() {
-            public_coin.reseed(&commitment.as_bytes());
-            let alpha = public_coin.draw().map_err(|_e| {
-                VerifierError::RandomCoinError(RandomCoinError::FailedToDrawFieldElement(1000))
-            })?;
-
-            layer_alphas.push(alpha);
-
-            // make sure the degree can be reduced by the folding factor at all layers
-            // but the remainder layer
-            if depth != layer_commitments.len() - 1
-                && max_degree_plus_1 % options.folding_factor() != 0
-            {
-                return Err(VerifierError::DegreeTruncation(
-                    max_degree_plus_1 - 1,
-                    options.folding_factor(),
-                    depth,
-                ));
-            }
-            max_degree_plus_1 /= options.folding_factor();
-        }
-
-        Ok(Self {
-            max_poly_degree,
-            domain_size,
-            domain_generator,
-            layer_commitments,
-            layer_alphas,
-            options,
-            num_partitions,
-            _channel: PhantomData,
-            _public_coin: PhantomData,
-        })
-    }
-
-    /// Returns protocol configuration options for this verifier.
-    pub fn options(&self) -> &FriOptions {
-        &self.options
-    }
-
-    pub fn check_auth(
-        &self,
-        channel: &mut C,
-        evaluations: &[E],
-        positions: &[usize],
-    ) -> Result<(), VerifierError> {
-        if evaluations.len() != positions.len() {
-            return Err(VerifierError::NumPositionEvaluationMismatch(
-                positions.len(),
-                evaluations.len(),
-            ));
-        }
-
-        // static dispatch for folding factor parameter
-        let folding_factor = self.options.folding_factor();
-        match folding_factor {
-            2 => self.verify_generic::<2>(channel, evaluations, positions),
-            4 => self.verify_generic::<4>(channel, evaluations, positions),
-            8 => self.verify_generic::<8>(channel, evaluations, positions),
-            16 => self.verify_generic::<16>(channel, evaluations, positions),
-            _ => Err(VerifierError::UnsupportedFoldingFactor(folding_factor)),
-        }
-    }
-
-    /// This is the actual implementation of the verification procedure described above, but it
-    /// also takes folding factor as a generic parameter N.
-    fn verify_generic<const N: usize>(
-        &self,
-        channel: &mut C,
-        evaluations: &[E],
-        positions: &[usize],
-    ) -> Result<(), VerifierError> {
-        // pre-compute roots of unity used in computing x coordinates in the folded domain
-        let folding_roots = (0..N)
-            .map(|i| {
-                self.domain_generator
-                    .exp_vartime(((self.domain_size / N * i) as u64).into())
-            })
-            .collect::<Vec<_>>();
-
-        // 1 ----- verify the recursive components of the FRI proof -----------------------------------
-        let mut domain_generator = self.domain_generator;
-        let mut domain_size = self.domain_size;
-        let mut max_degree_plus_1 = self.max_poly_degree + 1;
-        let mut positions = positions.to_vec();
-        let mut evaluations = evaluations.to_vec();
-
-        for depth in 0..self.options.num_fri_layers(self.domain_size) {
-            // determine which evaluations were queried in the folded layer
-            let mut folded_positions =
-                fold_positions(&positions, domain_size, self.options.folding_factor());
-            // determine where these evaluations are in the commitment Merkle tree
-            let position_indexes = map_positions_to_indexes(
-                &folded_positions,
-                domain_size,
-                self.options.folding_factor(),
-                self.num_partitions,
-            );
-            // read query values from the specified indexes in the Merkle tree
-            let layer_commitment = self.layer_commitments[depth];
-            // TODO: add layer depth to the potential error message
-            let layer_values = channel.read_layer_queries(&position_indexes, &layer_commitment)?;
-            let query_values =
-                get_query_values::<E, N>(&layer_values, &positions, &folded_positions, domain_size);
-            if evaluations != query_values {
-                return Err(VerifierError::InvalidLayerFolding(depth));
-            }
-
-            // build a set of x coordinates for each row polynomial
-            #[rustfmt::skip]
-            let xs = folded_positions.iter().map(|&i| {
-                let xe = domain_generator.exp_vartime((i as u64).into()) * self.options.domain_offset();
-                folding_roots.iter()
-                    .map(|&r| E::from(xe * r))
-                    .collect::<Vec<_>>().try_into().unwrap()
-            })
-            .collect::<Vec<_>>();
-
-            // interpolate x and y values into row polynomials
-            let row_polys = polynom::interpolate_batch(&xs, &layer_values);
-
-            // calculate the pseudo-random value used for linear combination in layer folding
-            let alpha = self.layer_alphas[depth];
-
-            // check that when the polynomials are evaluated at alpha, the result is equal to
-            // the corresponding column value
-            evaluations = row_polys.iter().map(|p| polynom::eval(p, alpha)).collect();
-
-            // make sure next degree reduction does not result in degree truncation
-            if max_degree_plus_1 % N != 0 {
-                return Err(VerifierError::DegreeTruncation(
-                    max_degree_plus_1 - 1,
-                    N,
-                    depth,
-                ));
-            }
-
-            // update variables for the next iteration of the loop
-            domain_generator = domain_generator.exp_vartime((N as u32).into());
-            max_degree_plus_1 /= N;
-            domain_size /= N;
-            mem::swap(&mut positions, &mut folded_positions);
-        }
-
-        // 2 ----- verify the remainder polynomial of the FRI proof -------------------------------
-
-        // read the remainder polynomial from the channel and make sure it agrees with the evaluations
-        // from the previous layer.
-        let remainder_poly = channel.read_remainder()?;
-        if remainder_poly.len() > max_degree_plus_1 {
-            return Err(VerifierError::RemainderDegreeMismatch(
-                max_degree_plus_1 - 1,
-            ));
-        }
-        let offset: E::BaseField = self.options().domain_offset();
-
-        for (&position, evaluation) in positions.iter().zip(evaluations) {
-            let comp_eval = eval_horner::<E>(
-                &remainder_poly,
-                offset * domain_generator.exp_vartime((position as u64).into()),
-            );
-            if comp_eval != evaluation {
-                return Err(VerifierError::InvalidRemainderFolding);
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn layer_alphas(&self) -> Vec<E> {
-        let alphas = &self.layer_alphas;
-        alphas.clone()
-    }
-}
+mod verifier;
+pub mod verifier_deprecated;
 
 fn get_query_values<E: FieldElement, const N: usize>(
     values: &[[E; N]],
@@ -264,4 +34,76 @@ where
     p.iter()
         .rev()
         .fold(E::ZERO, |acc, &coeff| acc * E::from(x) + coeff)
+}
+
+#[cfg(test)]
+mod tests {
+    use winter_crypto::hashers::Blake3_256;
+    use winter_fri::FriOptions;
+    use winter_math::fields::f128::BaseElement;
+    use winter_rand_utils::rand_vector;
+
+    use crate::{
+        frida_data::{build_evaluations_from_data, encoded_data_element_count},
+        frida_prover::{traits::BaseFriProver, FridaProver},
+        frida_prover_channel::FridaProverChannel,
+        frida_random::{FridaRandom, FridaRandomCoin},
+        frida_verifier::das::FridaDasVerifier,
+    };
+
+    #[test]
+    fn test_frida_das_verify() {
+        let max_remainder_degree = 7;
+        let folding_factor = 2;
+        let blowup_factor = 8;
+
+        let options = FriOptions::new(blowup_factor, folding_factor, max_remainder_degree);
+
+        // instantiate the prover and generate the proof
+        let mut prover: FridaProver<
+            BaseElement,
+            BaseElement,
+            FridaProverChannel<
+                BaseElement,
+                Blake3_256<BaseElement>,
+                Blake3_256<BaseElement>,
+                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
+            >,
+            Blake3_256<BaseElement>,
+        > = FridaProver::new(options.clone());
+
+        let data = rand_vector::<u8>(200);
+        let encoded_element_count =
+            encoded_data_element_count::<BaseElement>(data.len()).next_power_of_two();
+        let (commitment, _) = prover.commit(data.clone(), 31).unwrap();
+
+        let mut public_coin =
+            FridaRandom::<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>::new(&[
+                123,
+            ]);
+
+        let verifier = FridaDasVerifier::new(
+            commitment,
+            &mut public_coin,
+            options.clone(),
+            encoded_element_count - 1,
+        )
+        .unwrap();
+
+        // query for a position
+        let open_position = [1];
+        let proof = prover.open(&open_position);
+
+        let domain_size = (encoded_element_count - 1).next_power_of_two() * options.blowup_factor();
+        let evaluations: Vec<BaseElement> =
+            build_evaluations_from_data(&data, domain_size, options.blowup_factor()).unwrap();
+
+        let queried_evaluations = open_position
+            .iter()
+            .map(|&p| evaluations[p])
+            .collect::<Vec<_>>();
+        let result = verifier.verify(proof, &queried_evaluations, &open_position);
+
+        assert!(result.is_ok(), "{:?}", result.err().unwrap());
+    }
 }

--- a/src/frida_verifier/mod.rs
+++ b/src/frida_verifier/mod.rs
@@ -98,7 +98,7 @@ where
         &self.options
     }
 
-    pub fn verify(
+    pub fn check_auth(
         &self,
         channel: &mut C,
         evaluations: &[E],
@@ -232,7 +232,6 @@ where
         alphas.clone()
     }
 }
-
 
 fn get_query_values<E: FieldElement, const N: usize>(
     values: &[[E; N]],

--- a/src/frida_verifier/test.rs
+++ b/src/frida_verifier/test.rs
@@ -2,7 +2,7 @@
 mod test {
     use crate::frida_prover_channel::{BaseProverChannel, BaseProverChannelTest};
     use crate::frida_random::{FridaRandom, FridaRandomCoin};
-    use crate::frida_verifier::FridaVerifier;
+    use crate::frida_verifier::verifier_deprecated::FridaVerifierDeprecated;
     use crate::utils::{build_evaluations, build_prover_channel};
     use winter_crypto::hashers::Blake3_256;
     use winter_fri::{DefaultVerifierChannel, FriOptions, FriProver};
@@ -46,7 +46,8 @@ mod test {
         let mut coin = FridaRandom::<Blake3, Blake3, BaseElement>::new(&[123]);
 
         let verifier =
-            FridaVerifier::new(&mut channel, &mut coin, options.clone(), max_degree).unwrap();
+            FridaVerifierDeprecated::new(&mut channel, &mut coin, options.clone(), max_degree)
+                .unwrap();
 
         let layer_alpha = verifier.layer_alphas();
 

--- a/src/frida_verifier/verifier.rs
+++ b/src/frida_verifier/verifier.rs
@@ -7,7 +7,9 @@ use winter_fri::{
 };
 use winter_math::{polynom, FieldElement, StarkField};
 
-pub struct FridaVerifier2<E, HRandom>
+use super::eval_horner;
+
+pub struct FridaVerifier<E, HRandom>
 where
     E: FieldElement,
     HRandom: ElementHasher<BaseField = E::BaseField>,
@@ -21,7 +23,7 @@ where
     num_partitions: usize,
 }
 
-impl<E, HRandom> FridaVerifier2<E, HRandom>
+impl<E, HRandom> FridaVerifier<E, HRandom>
 where
     E: FieldElement,
     HRandom: ElementHasher<BaseField = E::BaseField>,
@@ -202,14 +204,4 @@ fn get_query_values<E: FieldElement, const N: usize>(
     }
 
     result
-}
-
-// Evaluates a polynomial with coefficients in an extension field at a point in the base field.
-pub fn eval_horner<E>(p: &[E], x: E::BaseField) -> E
-where
-    E: FieldElement,
-{
-    p.iter()
-        .rev()
-        .fold(E::ZERO, |acc, &coeff| acc * E::from(x) + coeff)
 }

--- a/src/frida_verifier/verifier2.rs
+++ b/src/frida_verifier/verifier2.rs
@@ -1,7 +1,6 @@
-use std::{marker::PhantomData, mem};
+use std::mem;
 
-use crate::{frida_prover::Commitment, frida_random::FridaRandomCoin};
-use winter_crypto::{Digest, ElementHasher, RandomCoinError};
+use winter_crypto::ElementHasher;
 use winter_fri::{
     folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierChannel,
     VerifierError,
@@ -181,11 +180,6 @@ where
         }
 
         Ok(())
-    }
-
-    pub fn layer_alphas(&self) -> Vec<E> {
-        let alphas = &self.layer_alphas;
-        alphas.clone()
     }
 }
 

--- a/src/frida_verifier/verifier_deprecated.rs
+++ b/src/frida_verifier/verifier_deprecated.rs
@@ -9,6 +9,8 @@ use winter_fri::{
 };
 use winter_math::{polynom, FieldElement, StarkField};
 
+// TODO: remove this struct as it is being replaced by FridaVerifier
+#[deprecated]
 pub struct FridaVerifierDeprecated<E, C, HHst, HRandom, R>
 where
     E: FieldElement,

--- a/src/frida_verifier/verifier_deprecated.rs
+++ b/src/frida_verifier/verifier_deprecated.rs
@@ -1,0 +1,233 @@
+use std::{marker::PhantomData, mem};
+
+use super::{eval_horner, get_query_values};
+use crate::frida_random::FridaRandomCoin;
+use winter_crypto::{Digest, ElementHasher, RandomCoinError};
+use winter_fri::{
+    folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierChannel,
+    VerifierError,
+};
+use winter_math::{polynom, FieldElement, StarkField};
+
+pub struct FridaVerifierDeprecated<E, C, HHst, HRandom, R>
+where
+    E: FieldElement,
+    C: VerifierChannel<E, Hasher = HRandom>,
+    HHst: ElementHasher<BaseField = E::BaseField>,
+    HRandom: ElementHasher<BaseField = E::BaseField>,
+    R: FridaRandomCoin<BaseField = E::BaseField, HashHst = HHst, HashRandom = HRandom>,
+{
+    max_poly_degree: usize,
+    domain_size: usize,
+    domain_generator: E::BaseField,
+    layer_commitments: Vec<HRandom::Digest>,
+    layer_alphas: Vec<E>,
+    options: FriOptions,
+    num_partitions: usize,
+    _channel: PhantomData<C>,
+    _public_coin: PhantomData<R>,
+}
+
+impl<E, C, HHst, HRandom, R> FridaVerifierDeprecated<E, C, HHst, HRandom, R>
+where
+    E: FieldElement,
+    C: VerifierChannel<E, Hasher = HRandom>,
+    HHst: ElementHasher<BaseField = E::BaseField>,
+    HRandom: ElementHasher<BaseField = E::BaseField>,
+    R: FridaRandomCoin<
+        BaseField = E::BaseField,
+        FieldElement = E,
+        HashHst = HHst,
+        HashRandom = HRandom,
+    >,
+{
+    pub fn new(
+        channel: &mut C,
+        public_coin: &mut R,
+        options: FriOptions,
+        max_poly_degree: usize,
+    ) -> Result<Self, VerifierError> {
+        // infer evaluation domain info
+        let domain_size = max_poly_degree.next_power_of_two() * options.blowup_factor();
+        let domain_generator = E::BaseField::get_root_of_unity(domain_size.ilog2());
+
+        let num_partitions = channel.read_fri_num_partitions();
+
+        // read layer commitments from the channel and use them to build a list of alphas
+        let layer_commitments = channel.read_fri_layer_commitments();
+        let mut layer_alphas = Vec::with_capacity(layer_commitments.len());
+        let mut max_degree_plus_1 = max_poly_degree + 1;
+        for (depth, commitment) in layer_commitments.iter().enumerate() {
+            public_coin.reseed(&commitment.as_bytes());
+            let alpha = public_coin.draw().map_err(|_e| {
+                VerifierError::RandomCoinError(RandomCoinError::FailedToDrawFieldElement(1000))
+            })?;
+
+            layer_alphas.push(alpha);
+
+            // make sure the degree can be reduced by the folding factor at all layers
+            // but the remainder layer
+            if depth != layer_commitments.len() - 1
+                && max_degree_plus_1 % options.folding_factor() != 0
+            {
+                return Err(VerifierError::DegreeTruncation(
+                    max_degree_plus_1 - 1,
+                    options.folding_factor(),
+                    depth,
+                ));
+            }
+            max_degree_plus_1 /= options.folding_factor();
+        }
+
+        Ok(Self {
+            max_poly_degree,
+            domain_size,
+            domain_generator,
+            layer_commitments,
+            layer_alphas,
+            options,
+            num_partitions,
+            _channel: PhantomData,
+            _public_coin: PhantomData,
+        })
+    }
+
+    /// Returns protocol configuration options for this verifier.
+    pub fn options(&self) -> &FriOptions {
+        &self.options
+    }
+
+    pub fn check_auth(
+        &self,
+        channel: &mut C,
+        evaluations: &[E],
+        positions: &[usize],
+    ) -> Result<(), VerifierError> {
+        if evaluations.len() != positions.len() {
+            return Err(VerifierError::NumPositionEvaluationMismatch(
+                positions.len(),
+                evaluations.len(),
+            ));
+        }
+
+        // static dispatch for folding factor parameter
+        let folding_factor = self.options.folding_factor();
+        match folding_factor {
+            2 => self.verify_generic::<2>(channel, evaluations, positions),
+            4 => self.verify_generic::<4>(channel, evaluations, positions),
+            8 => self.verify_generic::<8>(channel, evaluations, positions),
+            16 => self.verify_generic::<16>(channel, evaluations, positions),
+            _ => Err(VerifierError::UnsupportedFoldingFactor(folding_factor)),
+        }
+    }
+
+    /// This is the actual implementation of the verification procedure described above, but it
+    /// also takes folding factor as a generic parameter N.
+    fn verify_generic<const N: usize>(
+        &self,
+        channel: &mut C,
+        evaluations: &[E],
+        positions: &[usize],
+    ) -> Result<(), VerifierError> {
+        // pre-compute roots of unity used in computing x coordinates in the folded domain
+        let folding_roots = (0..N)
+            .map(|i| {
+                self.domain_generator
+                    .exp_vartime(((self.domain_size / N * i) as u64).into())
+            })
+            .collect::<Vec<_>>();
+
+        // 1 ----- verify the recursive components of the FRI proof -----------------------------------
+        let mut domain_generator = self.domain_generator;
+        let mut domain_size = self.domain_size;
+        let mut max_degree_plus_1 = self.max_poly_degree + 1;
+        let mut positions = positions.to_vec();
+        let mut evaluations = evaluations.to_vec();
+
+        for depth in 0..self.options.num_fri_layers(self.domain_size) {
+            // determine which evaluations were queried in the folded layer
+            let mut folded_positions =
+                fold_positions(&positions, domain_size, self.options.folding_factor());
+            // determine where these evaluations are in the commitment Merkle tree
+            let position_indexes = map_positions_to_indexes(
+                &folded_positions,
+                domain_size,
+                self.options.folding_factor(),
+                self.num_partitions,
+            );
+            // read query values from the specified indexes in the Merkle tree
+            let layer_commitment = self.layer_commitments[depth];
+            // TODO: add layer depth to the potential error message
+            let layer_values = channel.read_layer_queries(&position_indexes, &layer_commitment)?;
+            let query_values =
+                get_query_values::<E, N>(&layer_values, &positions, &folded_positions, domain_size);
+            if evaluations != query_values {
+                return Err(VerifierError::InvalidLayerFolding(depth));
+            }
+
+            // build a set of x coordinates for each row polynomial
+            #[rustfmt::skip]
+            let xs = folded_positions.iter().map(|&i| {
+                let xe = domain_generator.exp_vartime((i as u64).into()) * self.options.domain_offset();
+                folding_roots.iter()
+                    .map(|&r| E::from(xe * r))
+                    .collect::<Vec<_>>().try_into().unwrap()
+            })
+            .collect::<Vec<_>>();
+
+            // interpolate x and y values into row polynomials
+            let row_polys = polynom::interpolate_batch(&xs, &layer_values);
+
+            // calculate the pseudo-random value used for linear combination in layer folding
+            let alpha = self.layer_alphas[depth];
+
+            // check that when the polynomials are evaluated at alpha, the result is equal to
+            // the corresponding column value
+            evaluations = row_polys.iter().map(|p| polynom::eval(p, alpha)).collect();
+
+            // make sure next degree reduction does not result in degree truncation
+            if max_degree_plus_1 % N != 0 {
+                return Err(VerifierError::DegreeTruncation(
+                    max_degree_plus_1 - 1,
+                    N,
+                    depth,
+                ));
+            }
+
+            // update variables for the next iteration of the loop
+            domain_generator = domain_generator.exp_vartime((N as u32).into());
+            max_degree_plus_1 /= N;
+            domain_size /= N;
+            mem::swap(&mut positions, &mut folded_positions);
+        }
+
+        // 2 ----- verify the remainder polynomial of the FRI proof -------------------------------
+
+        // read the remainder polynomial from the channel and make sure it agrees with the evaluations
+        // from the previous layer.
+        let remainder_poly = channel.read_remainder()?;
+        if remainder_poly.len() > max_degree_plus_1 {
+            return Err(VerifierError::RemainderDegreeMismatch(
+                max_degree_plus_1 - 1,
+            ));
+        }
+        let offset: E::BaseField = self.options().domain_offset();
+
+        for (&position, evaluation) in positions.iter().zip(evaluations) {
+            let comp_eval = eval_horner::<E>(
+                &remainder_poly,
+                offset * domain_generator.exp_vartime((position as u64).into()),
+            );
+            if comp_eval != evaluation {
+                return Err(VerifierError::InvalidRemainderFolding);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn layer_alphas(&self) -> Vec<E> {
+        let alphas = &self.layer_alphas;
+        alphas.clone()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,7 @@ mod tests {
     use winter_math::fields::f128::BaseElement;
 
     use crate::{
-        frida_prover::{proof::FridaProof, traits::BaseFriProver, FridaProver},
-        frida_prover_channel::BaseProverChannel,
-        frida_random::{FridaRandom, FridaRandomCoin},
-        frida_verifier::FridaVerifier,
-        frida_verifier_channel::FridaVerifierChannel,
-        utils::{build_evaluations, build_prover_channel},
+        frida_prover::{proof::FridaProof, traits::BaseFriProver, FridaProver}, frida_prover_channel::BaseProverChannel, frida_random::{FridaRandom, FridaRandomCoin}, frida_verifier::verifier_deprecated::FridaVerifierDeprecated, frida_verifier_channel::FridaVerifierChannel, utils::{build_evaluations, build_prover_channel}
     };
 
     #[test]
@@ -46,7 +41,7 @@ mod tests {
             let mut coin = FridaRandom::<Blake3, Blake3, BaseElement>::new(&[123]);
 
             let verifier =
-                FridaVerifier::new(&mut channel, &mut coin, options.clone(), max_degree)?;
+                FridaVerifierDeprecated::new(&mut channel, &mut coin, options.clone(), max_degree)?;
 
             let queried_evaluations = positions
                 .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod tests {
                 .iter()
                 .map(|&p| evaluations[p])
                 .collect::<Vec<_>>();
-            verifier.verify(&mut channel, &queried_evaluations, positions)
+            verifier.check_auth(&mut channel, &queried_evaluations, positions)
         }
 
         fn fri_prove_verify(


### PR DESCRIPTION
Modify
- `Commitment` to add `num_queries` in order for verifier to know how many queries were made in order to construct the folding correctness proof
-  `build_evaluations_from_data` and refactor the reed solomon portion to a separate function. a test has also been added to it

Added
- `FridaDasVerifier` that accepts a `Commitment` struct on initialization and will also check for the correct of folding proof
- added `verify` function check for correctness of frida proof

Mark original `FridaVerifier` struct as deprecated