### PR TITLE
Use batched layer as first layer

### DIFF
--- a/src/frida_data.rs
+++ b/src/frida_data.rs
@@ -45,7 +45,7 @@ fn data_to_field_element<E: FieldElement>(
     for chunk in encoded_data.chunks(E::ELEMENT_BYTES) {
         match E::read_from_bytes(chunk) {
             Ok(val) => symbols.push(val),
-            Err(_) => return Err(FridaError::DeserializationError()),
+            Err(e) => return Err(FridaError::DeserializationError(e)),
         };
     }
     Ok(symbols)

--- a/src/frida_error.rs
+++ b/src/frida_error.rs
@@ -1,6 +1,8 @@
+use winter_utils::DeserializationError;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FridaError {
-    DeserializationError(),
+    DeserializationError(DeserializationError),
     XYCoordinateLengthMismatch(),
     NotEnoughDataPoints(),
     BadDataLength(),
@@ -15,4 +17,6 @@ pub enum FridaError {
     /// Polynomial degree at one of the FRI layers could not be divided evenly by the folding factor.
     DegreeTruncation(usize, usize, usize),
     UnsupportedFoldingFactor(usize),
+    SinglePolyBatch(),
+    ProofPolyCountMismatch(),
 }

--- a/src/frida_error.rs
+++ b/src/frida_error.rs
@@ -1,8 +1,6 @@
-use winter_utils::DeserializationError;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FridaError {
-    DeserializationError(DeserializationError),
+    DeserializationError(winter_utils::DeserializationError),
     XYCoordinateLengthMismatch(),
     NotEnoughDataPoints(),
     BadDataLength(),
@@ -17,6 +15,6 @@ pub enum FridaError {
     /// Polynomial degree at one of the FRI layers could not be divided evenly by the folding factor.
     DegreeTruncation(usize, usize, usize),
     UnsupportedFoldingFactor(usize),
-    SinglePolyBatch(),
-    ProofPolyCountMismatch(),
+    SinglePolyBatch,
+    ProofPolyCountMismatch,
 }

--- a/src/frida_prover/base_tests.rs
+++ b/src/frida_prover/base_tests.rs
@@ -61,7 +61,7 @@ fn fri_trait_check(
 
     let mut frida_channel = build_prover_channel(trace_length, &options);
     let mut frida_prover = FridaProver::new(options);
-    frida_prover.build_layers(&mut frida_channel, evaluations);
+    frida_prover.build_layers(&mut frida_channel, evaluations, false);
     let frida_proof = frida_prover.build_proof(&positions);
 
     assert_eq!(

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -158,7 +158,11 @@ where
         let blowup_factor = self.options.blowup_factor();
 
         let max_data_len = encoded_data_element_count::<E>(
-            data_list.iter().map(|data| data.len()).max().unwrap_or_default()    
+            data_list
+                .iter()
+                .map(|data| data.len())
+                .max()
+                .unwrap_or_default(),
         );
 
         let domain_size = usize::max(

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -15,7 +15,7 @@ use proof::FridaProof;
 
 #[cfg(feature = "concurrent")]
 use winter_utils::iterators::*;
-use winter_utils::{iter_mut, uninit_vector};
+use winter_utils::uninit_vector;
 
 use crate::{
     frida_const,
@@ -32,8 +32,8 @@ where
     H: ElementHasher<BaseField = B>,
 {
     options: FriOptions,
-    batch_layer: Option<BatchFridaLayer<B, E, H>>,
     layers: Vec<FridaLayer<B, E, H>>,
+    poly_count: usize,
     remainder_poly: FridaRemainder<E>,
     channel: Option<C>,
 }
@@ -41,12 +41,6 @@ where
 pub struct FridaLayer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> {
     tree: MerkleTree<H>,
     pub evaluations: Vec<E>,
-    _base_field: PhantomData<B>,
-}
-
-pub struct BatchFridaLayer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> {
-    tree: MerkleTree<H>,
-    pub evaluations: Vec<Vec<E>>,
     _base_field: PhantomData<B>,
 }
 
@@ -59,7 +53,7 @@ pub struct Commitment<HRoot: ElementHasher> {
     // In a real protocol, domain size will likely be predefined and won't be part of a block.
     pub domain_size: usize,
     pub num_queries: usize,
-    pub batch_size: usize,
+    pub poly_count: usize,
 }
 
 #[cfg(feature = "bench")]
@@ -83,8 +77,8 @@ where
     fn new(options: FriOptions) -> Self {
         FridaProver {
             options,
-            batch_layer: None,
             layers: Vec::new(),
+            poly_count: 1,
             remainder_poly: FridaRemainder(vec![]),
             channel: None,
         }
@@ -99,7 +93,7 @@ where
     }
 
     fn domain_size(&self) -> usize {
-        self.layers[0].evaluations.len()
+        self.layers[0].evaluations.len() / self.poly_count
     }
 
     fn domain_offset(&self) -> B {
@@ -116,6 +110,7 @@ where
 
     fn reset(&mut self) {
         self.layers.clear();
+        self.poly_count = 1;
         self.remainder_poly.0.clear();
         self.channel = None;
     }
@@ -127,16 +122,17 @@ where
     fn get_layer(&self, index: usize) -> &FridaLayer<B, E, H> {
         &self.layers[index]
     }
-    fn get_batch_layer(&self) -> &Option<BatchFridaLayer<B, E, H>> {
-        &self.batch_layer
-    }
 
     fn set_remainer_poly(&mut self, remainder: FridaRemainder<E>) {
         self.remainder_poly = remainder;
     }
 
     fn is_batch(&self) -> bool {
-        !self.batch_layer.is_none()
+        self.poly_count > 1
+    }
+
+    fn poly_count(&self) -> usize {
+        self.poly_count
     }
 }
 
@@ -157,19 +153,27 @@ where
             bench::TIMER = Some(Instant::now());
         }
 
-        let batch_size = data_list.len();
+        self.poly_count = data_list.len();
+        if self.poly_count <= 1 {
+            return Err(FridaError::SinglePolyBatch());
+        }
+
         let blowup_factor = self.options.blowup_factor();
+
         let mut max_data_len = 0;
         data_list.iter().for_each(|data| {
-            max_data_len = usize::max(encoded_data_element_count::<E>(data.len()), max_data_len);
+            max_data_len = usize::max(data.len(), max_data_len);
         });
+        max_data_len = encoded_data_element_count::<E>(max_data_len);
 
         let domain_size = usize::max(
             (max_data_len * blowup_factor).next_power_of_two(),
             frida_const::MIN_DOMAIN_SIZE,
         );
+
         let folding_factor = self.folding_factor();
         let bucket_count = domain_size / folding_factor;
+        let bucket_size = self.poly_count * folding_factor;
 
         if domain_size > frida_const::MAX_DOMAIN_SIZE {
             return Err(FridaError::DomainSizeTooBig(domain_size));
@@ -178,17 +182,15 @@ where
             return Err(FridaError::BadNumQueries(num_queries));
         }
 
-        let mut evaluations = vec![
-            unsafe { uninit_vector(batch_size * folding_factor) };
-            domain_size / folding_factor
-        ];
-
+        let mut evaluations = unsafe { uninit_vector(self.poly_count * domain_size) };
         for (i, data) in data_list.iter().enumerate() {
             build_evaluations_from_data::<E>(data, domain_size, blowup_factor)?
                 .into_iter()
                 .enumerate()
                 .for_each(|(j, e)| {
-                    evaluations[j % bucket_count][batch_size * (j / bucket_count) + i] = e;
+                    let bucket = j % bucket_count;
+                    let position = i + self.poly_count * (j / bucket_count);
+                    evaluations[bucket * bucket_size + position] = e;
                 });
         }
 
@@ -199,46 +201,15 @@ where
             bench::TIMER = Some(Instant::now());
         }
 
-        let mut channel = if num_queries == 0 {
-            C::new(domain_size, 1)
+        if num_queries == 0 {
+            let mut channel = C::new(domain_size, 1);
+            self.build_layers_batched(&mut channel, evaluations, domain_size)?;
         } else {
-            C::new(domain_size, num_queries)
-        };
-
-        let len = evaluations.len();
-        let mut hashed_evaluations: Vec<H::Digest> = unsafe { uninit_vector(len) };
-        iter_mut!(hashed_evaluations, 1024)
-            .zip(&evaluations)
-            .for_each(|(r, v)| {
-                *r = H::hash_elements(v);
-            });
-        let evaluation_tree =
-            MerkleTree::<H>::new(hashed_evaluations).expect("failed to construct FRI layer tree");
-
-        channel.commit_fri_layer(*evaluation_tree.root());
-        let xi = channel.draw_xi(batch_size)?;
-        let mut final_eval = unsafe { uninit_vector(domain_size) };
-        iter_mut!(final_eval, 1024).enumerate().for_each(|(i, f)| {
-            *f = E::default();
-            let start = batch_size * (i / bucket_count);
-            evaluations[i % bucket_count][start..start + batch_size]
-                .iter()
-                .enumerate()
-                .for_each(|(j, e)| {
-                    *f += *e * xi[j];
-                });
-        });
-
-        self.batch_layer = Some(BatchFridaLayer {
-            tree: evaluation_tree,
-            evaluations: evaluations,
-            _base_field: PhantomData,
-        });
-        self.build_layers(&mut channel, final_eval);
-
-        if num_queries != 0 {
+            let mut channel = C::new(domain_size, num_queries);
+            self.build_layers_batched(&mut channel, evaluations, domain_size)?;
             self.channel = Some(channel);
         }
+
         Ok(())
     }
 
@@ -268,7 +239,7 @@ where
             return Err(FridaError::BadNumQueries(num_queries));
         }
 
-        let evaluations = build_evaluations_from_data(&data, domain_size, blowup_factor)?;
+        let evaluations = build_evaluations_from_data(data, domain_size, blowup_factor)?;
 
         #[cfg(feature = "bench")]
         unsafe {
@@ -315,7 +286,7 @@ where
             proof,
             domain_size: self.domain_size(),
             num_queries,
-            batch_size: 0,
+            poly_count: 1,
         };
 
         Ok((commitment, data))
@@ -329,7 +300,12 @@ where
         if num_queries == 0 {
             return Err(FridaError::BadNumQueries(num_queries));
         }
-        self.build_layers_from_batched_data(&data, num_queries)?;
+        let build_layers = self.build_layers_from_batched_data(&data, num_queries);
+        if build_layers.is_err() {
+            self.poly_count = 1;
+            build_layers?;
+        }
+
         let proof = self.query();
 
         #[cfg(feature = "bench")]
@@ -345,7 +321,7 @@ where
             proof,
             domain_size: self.domain_size(),
             num_queries,
-            batch_size: data.len(),
+            poly_count: data.len(),
         };
 
         Ok((commitment, data))
@@ -454,7 +430,7 @@ mod tests {
                 proof: proof,
                 domain_size,
                 num_queries,
-                batch_size: 0
+                poly_count: 1
             }
         );
         assert_eq!(state, data);
@@ -514,9 +490,9 @@ mod tests {
 
     #[test]
     fn test_batching() {
-        let batch_size = 10;
+        let poly_count = 10;
         let mut data = vec![];
-        for _ in 0..batch_size {
+        for _ in 0..poly_count {
             data.push(rand_vector::<u8>(usize::min(
                 rand_value::<u64>() as usize,
                 1024,
@@ -559,25 +535,7 @@ mod tests {
             Blake3_256<BaseElement>,
             FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
         >::new(prover.domain_size(), 1);
-        channel.commit_fri_layer(commitment.roots[0]);
-        let xi = channel.draw_xi(batch_size).unwrap();
-
-        // Sanity checks
-        for i in 0..prover.domain_size() {
-            assert_eq!(
-                opening_prover.layers[0].evaluations[i],
-                prover.batch_layer.as_ref().unwrap().evaluations[i / folding_factor]
-                    .iter()
-                    .skip(i % folding_factor * batch_size)
-                    .take(batch_size)
-                    .enumerate()
-                    .fold(BaseElement::default(), |accum, (j, e)| {
-                        accum + xi[j] * *e
-                    })
-            );
-        }
-
-        for layer_root in commitment.roots[1..].iter() {
+        for layer_root in commitment.roots.iter() {
             channel.commit_fri_layer(*layer_root);
         }
         let query_positions = fold_positions(
@@ -588,7 +546,7 @@ mod tests {
         let mut opening_prover_query_proof = opening_prover.open(&query_positions);
         assert_eq!(commitment.proof, opening_prover_query_proof);
 
-        let (values, merkle_proof) = opening_prover_query_proof
+        let (_, merkle_proof) = opening_prover_query_proof
             .parse_batch_layer::<Blake3_256<BaseElement>, BaseElement>(
                 prover.domain_size(),
                 folding_factor,
@@ -602,7 +560,7 @@ mod tests {
         )
         .unwrap();
 
-        let (layers, _) = commitment
+        commitment
             .proof
             .parse_layers::<Blake3_256<BaseElement>, BaseElement>(
                 prover.domain_size(),
@@ -610,18 +568,10 @@ mod tests {
             )
             .unwrap();
 
-        for (i, value) in layers[0].iter().enumerate() {
-            assert_eq!(
-                *value,
-                values[0]
-                    .iter()
-                    .skip(i * batch_size)
-                    .take(batch_size)
-                    .enumerate()
-                    .fold(BaseElement::default(), |accumulator, (j, val)| {
-                        accumulator + xi[j] * *val
-                    })
-            )
-        }
+        prover.reset();
+        assert_eq!(
+            FridaError::SinglePolyBatch(),
+            prover.commit_batch(vec![vec![]], 1).unwrap_err()
+        );
     }
 }

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -152,16 +152,14 @@ where
 
         self.poly_count = data_list.len();
         if self.poly_count <= 1 {
-            return Err(FridaError::SinglePolyBatch());
+            return Err(FridaError::SinglePolyBatch);
         }
 
         let blowup_factor = self.options.blowup_factor();
 
-        let mut max_data_len = 0;
-        data_list.iter().for_each(|data| {
-            max_data_len = usize::max(data.len(), max_data_len);
-        });
-        max_data_len = encoded_data_element_count::<E>(max_data_len);
+        let max_data_len = encoded_data_element_count::<E>(
+            data_list.iter().map(|data| data.len()).max().unwrap_or_default()    
+        );
 
         let domain_size = usize::max(
             (max_data_len * blowup_factor).next_power_of_two(),
@@ -567,7 +565,7 @@ mod tests {
 
         prover.reset();
         assert_eq!(
-            FridaError::SinglePolyBatch(),
+            FridaError::SinglePolyBatch,
             prover.commit_batch(vec![vec![]], 1).unwrap_err()
         );
     }

--- a/src/frida_prover/mod.rs
+++ b/src/frida_prover/mod.rs
@@ -12,9 +12,6 @@ use winter_fri::FriOptions;
 pub mod proof;
 pub mod traits;
 use proof::FridaProof;
-
-#[cfg(feature = "concurrent")]
-use winter_utils::iterators::*;
 use winter_utils::uninit_vector;
 
 use crate::{

--- a/src/frida_prover/proof.rs
+++ b/src/frida_prover/proof.rs
@@ -8,7 +8,7 @@ use winter_utils::{
 // ================================================================================================
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FridaProof {
-    batch_layer: Option<FridaProofBatchLayer>,
+    pub(crate) batch_layer: Option<FridaProofBatchLayer>,
     layers: Vec<FridaProofLayer>,
     remainder: Vec<u8>,
     num_partitions: u8, // stored as power of 2
@@ -158,8 +158,8 @@ impl FridaProof {
         &mut self,
         domain_size: usize,
         folding_factor: usize,
-        batch_size: usize,
-    ) -> Result<(Vec<Vec<E>>, BatchMerkleProof<H>), DeserializationError>
+        poly_count: usize,
+    ) -> Result<(Vec<E>, BatchMerkleProof<H>), DeserializationError>
     where
         E: FieldElement,
         H: ElementHasher<BaseField = E::BaseField>,
@@ -173,14 +173,14 @@ impl FridaProof {
             "folding factor must be a power of two"
         );
         assert!(folding_factor > 1, "folding factor must be greater than 1");
-        assert!(batch_size > 0, "batch size must be greater than 0");
+        assert!(poly_count > 1, "poly_count must be greater than 1");
 
         if let Some(layer) = self.batch_layer.take() {
-            return Ok(layer.parse::<H, E>(domain_size, folding_factor, batch_size)?);
+            return layer.parse::<H, E>(domain_size, folding_factor, poly_count);
         }
-        return Err(DeserializationError::InvalidValue(format!(
-            "failed to parse Batch Layer: it does not exist"
-        )));
+        Err(DeserializationError::InvalidValue(
+            "failed to parse Batch Layer: it does not exist".to_string(),
+        ))
     }
 
     /// Returns a vector of remainder values (last FRI layer) parsed from this proof.
@@ -241,12 +241,11 @@ impl Deserializable for FridaProof {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         // read batch layer
         let has_batch_layer = source.read_u8()? == 1;
-        let batch_layer: Option<FridaProofBatchLayer>;
-        if has_batch_layer {
-            batch_layer = Some(source.read()?);
+        let batch_layer = if has_batch_layer {
+            Some(source.read()?)
         } else {
-            batch_layer = None;
-        }
+            None
+        };
 
         // read layers
         let num_layers = source.read_u8()? as usize;
@@ -420,17 +419,14 @@ pub struct FridaProofBatchLayer {
 
 impl FridaProofBatchLayer {
     pub(crate) fn new<H: Hasher, E: FieldElement>(
-        query_values: Vec<&Vec<E>>,
+        query_values: Vec<E>,
         merkle_proof: BatchMerkleProof<H>,
     ) -> Self {
         assert!(!query_values.is_empty(), "query values cannot be empty");
 
         // TODO: add debug check that values actually hash into the leaf nodes of the batch proof
-
-        let mut value_bytes =
-            Vec::with_capacity(E::ELEMENT_BYTES * query_values[0].len() * query_values.len());
-        let iter_over_elements = query_values.into_iter().flatten();
-        value_bytes.write_many(iter_over_elements);
+        let mut value_bytes = Vec::with_capacity(E::ELEMENT_BYTES * query_values.len());
+        value_bytes.write_many(&query_values);
 
         // concatenate all query values and all internal Merkle proof nodes into vectors of bytes;
         // we care about internal nodes only because leaf nodes can be reconstructed from hashes
@@ -450,14 +446,16 @@ impl FridaProofBatchLayer {
         self,
         domain_size: usize,
         folding_factor: usize,
-        batch_size: usize,
-    ) -> Result<(Vec<Vec<E>>, BatchMerkleProof<H>), DeserializationError>
+        poly_count: usize,
+    ) -> Result<(Vec<E>, BatchMerkleProof<H>), DeserializationError>
     where
         E: FieldElement,
         H: ElementHasher<BaseField = E::BaseField>,
     {
+        let bucket_size = poly_count * folding_factor;
+
         // make sure the number of value bytes can be parsed into a whole number of queries
-        let num_query_bytes = E::ELEMENT_BYTES * batch_size * folding_factor;
+        let num_query_bytes = E::ELEMENT_BYTES * bucket_size;
         if self.values.len() % num_query_bytes != 0 {
             return Err(DeserializationError::InvalidValue(format!(
                 "number of value bytes ({}) does not divide into whole number of queries",
@@ -472,15 +470,15 @@ impl FridaProofBatchLayer {
             ));
         }
         let mut hashed_queries = vec![H::Digest::default(); num_queries];
-        let mut query_values = Vec::with_capacity(num_queries * batch_size * folding_factor);
 
         // read bytes corresponding to each query, convert them into field elements,
         // and also hash them to build leaf nodes of the batch Merkle proof
         let mut reader = SliceReader::new(&self.values);
-        for query_hash in hashed_queries.iter_mut() {
-            let qe = reader.read_many::<E>(batch_size * folding_factor)?;
-            *query_hash = H::hash_elements(&qe);
-            query_values.push(qe);
+        let query_values = reader.read_many::<E>(num_queries * bucket_size)?;
+
+        for (i, query_hash) in hashed_queries.iter_mut().enumerate() {
+            *query_hash =
+                H::hash_elements(&query_values[i * bucket_size..i * bucket_size + bucket_size]);
         }
         if reader.has_more_bytes() {
             return Err(DeserializationError::UnconsumedBytes);

--- a/src/frida_prover/proof.rs
+++ b/src/frida_prover/proof.rs
@@ -8,7 +8,7 @@ use winter_utils::{
 // ================================================================================================
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FridaProof {
-    pub(crate) batch_layer: Option<FridaProofBatchLayer>,
+    batch_layer: Option<FridaProofBatchLayer>,
     layers: Vec<FridaProofLayer>,
     remainder: Vec<u8>,
     num_partitions: u8, // stored as power of 2
@@ -70,6 +70,10 @@ impl FridaProof {
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
+
+    pub fn has_batch_layer(&self) -> bool {
+        return self.batch_layer.is_some()
+    }
 
     /// Returns the number of layers in this proof.
     pub fn num_layers(&self) -> usize {
@@ -179,7 +183,7 @@ impl FridaProof {
             return layer.parse::<H, E>(domain_size, folding_factor, poly_count);
         }
         Err(DeserializationError::InvalidValue(
-            "failed to parse Batch Layer: it does not exist".to_string(),
+            "failed to parse Batch Layer: it does not exist".to_owned(),
         ))
     }
 

--- a/src/frida_prover/proof.rs
+++ b/src/frida_prover/proof.rs
@@ -72,7 +72,7 @@ impl FridaProof {
     // --------------------------------------------------------------------------------------------
 
     pub fn has_batch_layer(&self) -> bool {
-        return self.batch_layer.is_some()
+        self.batch_layer.is_some()
     }
 
     /// Returns the number of layers in this proof.

--- a/src/frida_prover/traits.rs
+++ b/src/frida_prover/traits.rs
@@ -249,7 +249,7 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
 }
 
 fn apply_drp_batched<B: StarkField, E: FieldElement<BaseField = B>, const N: usize>(
-    evaluations: &Vec<E>,
+    evaluations: &[E],
     poly_count: usize,
     options: &FriOptions,
     xi: Vec<E>,

--- a/src/frida_prover/traits.rs
+++ b/src/frida_prover/traits.rs
@@ -2,19 +2,24 @@ use core::marker::PhantomData;
 
 use winter_crypto::{ElementHasher, Hasher, MerkleTree};
 use winter_math::{fft, FieldElement, StarkField};
-use winter_utils::{flatten_vector_elements, group_slice_elements, transpose_slice};
+use winter_utils::{
+    flatten_vector_elements, group_slice_elements, iter_mut, transpose_slice, uninit_vector,
+};
 
 use winter_fri::{
     folding::{apply_drp, fold_positions},
     utils::hash_values,
-    FriOptions, ProverChannel,
+    FriOptions,
 };
 
-use crate::frida_prover::proof::FridaProofBatchLayer;
+use crate::{
+    frida_error::FridaError, frida_prover::proof::FridaProofBatchLayer,
+    frida_prover_channel::BaseProverChannel,
+};
 
 use super::{
     proof::{FridaProof, FridaProofLayer},
-    BatchFridaLayer, FridaLayer, FridaRemainder,
+    FridaLayer, FridaRemainder,
 };
 
 // TRAIT implementing the default behavior for a fri prover
@@ -23,7 +28,7 @@ pub trait BaseFriProver<B, E, C, H>
 where
     B: StarkField,
     E: FieldElement<BaseField = B>,
-    C: ProverChannel<E, Hasher = H>,
+    C: BaseProverChannel<E, H>,
     H: ElementHasher<BaseField = B>,
 {
     fn new(options: FriOptions) -> Self;
@@ -33,24 +38,93 @@ where
     fn domain_offset(&self) -> B;
     fn remainder_poly(&self) -> &FridaRemainder<E>;
     fn num_layers(&self) -> usize;
+    fn poly_count(&self) -> usize;
     fn is_batch(&self) -> bool;
     fn reset(&mut self);
 
     fn store_layer(&mut self, layer: FridaLayer<B, E, H>);
     fn get_layer(&self, index: usize) -> &FridaLayer<B, E, H>;
-    fn get_batch_layer(&self) -> &Option<BatchFridaLayer<B, E, H>>;
     fn set_remainer_poly(&mut self, remainder: FridaRemainder<E>);
+
+    fn build_layers_batched(
+        &mut self,
+        channel: &mut C,
+        evaluations: Vec<E>,
+        domain_size: usize,
+    ) -> Result<(), FridaError> {
+        let poly_count = self.poly_count();
+        let folding_factor = self.folding_factor();
+        let bucket_count = domain_size / folding_factor;
+
+        let mut hashed_evaluations: Vec<H::Digest> = unsafe { uninit_vector(bucket_count) };
+        iter_mut!(hashed_evaluations, 1024)
+            .zip(evaluations.chunks(poly_count * folding_factor))
+            .for_each(|(r, v)| {
+                *r = H::hash_elements(v);
+            });
+        let evaluation_tree =
+            MerkleTree::<H>::new(hashed_evaluations).expect("failed to construct FRI layer tree");
+        channel.commit_fri_layer(*evaluation_tree.root());
+
+        let xi = channel.draw_xi(poly_count)?;
+        let alpha = channel.draw_fri_alpha();
+        let second_layer = match folding_factor {
+            2 => apply_drp_batched::<E::BaseField, E, 2>(
+                &evaluations,
+                poly_count,
+                self.options(),
+                xi,
+                alpha,
+            ),
+            4 => apply_drp_batched::<E::BaseField, E, 4>(
+                &evaluations,
+                poly_count,
+                self.options(),
+                xi,
+                alpha,
+            ),
+            8 => apply_drp_batched::<E::BaseField, E, 8>(
+                &evaluations,
+                poly_count,
+                self.options(),
+                xi,
+                alpha,
+            ),
+            16 => apply_drp_batched::<E::BaseField, E, 16>(
+                &evaluations,
+                poly_count,
+                self.options(),
+                xi,
+                alpha,
+            ),
+            _ => unimplemented!("folding factor {} is not supported", self.folding_factor()),
+        };
+
+        self.store_layer(FridaLayer {
+            tree: evaluation_tree,
+            evaluations,
+            _base_field: PhantomData,
+        });
+        self.build_layers(channel, second_layer);
+        Ok(())
+    }
 
     fn build_layers(&mut self, channel: &mut C, mut evaluations: Vec<E>) {
         assert!(
-            self.num_layers() == 0,
+            self.num_layers() == 0 || (self.is_batch() && self.num_layers() == 1),
             "a prior proof generation request has not been completed yet"
         );
+        let domain_size = if self.is_batch() {
+            self.domain_size()
+        } else {
+            evaluations.len()
+        };
 
         // reduce the degree by folding_factor at each iteration until the remaining polynomial
         // has small enough degree
-        let num_fri_layers = self.options().num_fri_layers(evaluations.len());
-        for _ in 0..num_fri_layers {
+        let num_fri_layers = self.options().num_fri_layers(domain_size);
+        let start = if self.is_batch() { 1 } else { 0 };
+        for _ in start..num_fri_layers {
             match self.folding_factor() {
                 2 => self.build_layer::<2>(channel, &mut evaluations),
                 4 => self.build_layer::<4>(channel, &mut evaluations),
@@ -111,24 +185,47 @@ where
         );
 
         let layers_len = self.num_layers();
-        let mut layers = Vec::with_capacity(layers_len);
+        let mut batch_layer = None;
+        let mut layers = Vec::with_capacity(layers_len - 1);
 
         if layers_len != 0 {
             let mut positions = positions.to_vec();
             let mut domain_size = self.domain_size();
             let folding_factor = self.options().folding_factor();
 
+            let start = if self.is_batch() { 1 } else { 0 };
+            if start == 1 {
+                positions = fold_positions(&positions, domain_size, folding_factor);
+                let proof = self
+                    .get_layer(0)
+                    .tree
+                    .prove_batch(&positions)
+                    .expect("failed to generate a Merkle proof for FRI layer queries");
+                let evaluations = &self.get_layer(0).evaluations;
+                let bucket_size = self.poly_count() * folding_factor;
+                let mut queried_values: Vec<E> = Vec::with_capacity(positions.len() * bucket_size);
+                for &position in positions.iter() {
+                    evaluations[bucket_size * position..bucket_size * position + bucket_size]
+                        .iter()
+                        .for_each(|e| {
+                            queried_values.push(*e);
+                        });
+                }
+                batch_layer = Some(FridaProofBatchLayer::new(queried_values, proof));
+                domain_size /= folding_factor;
+            }
+
             // for all FRI layers, except the last one, record tree root, determine a set of query
             // positions, and query the layer at these positions.
-            for i in 0..layers_len {
+            for i in start..layers_len {
                 positions = fold_positions(&positions, domain_size, folding_factor);
 
                 // sort of a static dispatch for folding_factor parameter
                 let proof_layer = match folding_factor {
-                    2 => query_layer::<B, E, H, 2>(&self.get_layer(i), &positions),
-                    4 => query_layer::<B, E, H, 4>(&self.get_layer(i), &positions),
-                    8 => query_layer::<B, E, H, 8>(&self.get_layer(i), &positions),
-                    16 => query_layer::<B, E, H, 16>(&self.get_layer(i), &positions),
+                    2 => query_layer::<B, E, H, 2>(self.get_layer(i), &positions),
+                    4 => query_layer::<B, E, H, 4>(self.get_layer(i), &positions),
+                    8 => query_layer::<B, E, H, 8>(self.get_layer(i), &positions),
+                    16 => query_layer::<B, E, H, 16>(self.get_layer(i), &positions),
                     _ => unimplemented!("folding factor {} is not supported", folding_factor),
                 };
 
@@ -139,26 +236,6 @@ where
 
         // use the remaining polynomial values directly as proof
         let remainder = self.remainder_poly().0.clone();
-
-        let mut batch_layer = None;
-
-        if self.is_batch() {
-            let positions = fold_positions(&positions, self.domain_size(), self.folding_factor());
-            let proof = self
-                .get_batch_layer()
-                .as_ref()
-                .unwrap()
-                .tree
-                .prove_batch(&positions)
-                .expect("failed to generate a Merkle proof for FRI layer queries");
-            let evaluations = &self.get_batch_layer().as_ref().unwrap().evaluations;
-            let mut queried_values: Vec<&Vec<E>> = Vec::with_capacity(positions.len());
-            for &position in positions.iter() {
-                queried_values.push(&evaluations[position]);
-            }
-            batch_layer = Some(FridaProofBatchLayer::new(queried_values, proof));
-        }
-
         FridaProof::new(batch_layer, layers, remainder, 1)
     }
 }
@@ -188,4 +265,32 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
     }
 
     FridaProofLayer::new(queried_values, proof)
+}
+
+fn apply_drp_batched<B: StarkField, E: FieldElement<BaseField = B>, const N: usize>(
+    evaluations: &Vec<E>,
+    poly_count: usize,
+    options: &FriOptions,
+    xi: Vec<E>,
+    alpha: E,
+) -> Vec<E> {
+    let domain_size = evaluations.len() / poly_count;
+    let bucket_count = domain_size / options.folding_factor();
+    let bucket_size = poly_count * N;
+
+    let mut final_eval: Vec<[E; N]> = unsafe { uninit_vector(bucket_count) };
+    iter_mut!(final_eval, 1024).enumerate().for_each(|(i, b)| {
+        iter_mut!(b, 1024).enumerate().for_each(|(j, f)| {
+            *f = E::default();
+            let start = i * bucket_size + poly_count * j;
+            evaluations[start..start + poly_count]
+                .iter()
+                .enumerate()
+                .for_each(|(j, e)| {
+                    *f += *e * xi[j];
+                });
+        });
+    });
+
+    apply_drp(&final_eval, options.domain_offset(), alpha)
 }

--- a/src/frida_prover/traits.rs
+++ b/src/frida_prover/traits.rs
@@ -173,8 +173,6 @@ where
             let mut positions = positions.to_vec();
             let mut domain_size = self.domain_size();
             let folding_factor = self.options().folding_factor();
-
-            
             if self.is_batch() {
                 positions = fold_positions(&positions, domain_size, folding_factor);
                 let proof = self
@@ -260,10 +258,9 @@ fn apply_drp_batched<B: StarkField, E: FieldElement<BaseField = B>, const N: usi
     let bucket_count = domain_size / options.folding_factor();
     let bucket_size = poly_count * N;
 
-    let mut final_eval: Vec<[E; N]> = unsafe { uninit_vector(bucket_count) };
+    let mut final_eval: Vec<[E; N]> = vec![[E::default(); N]; bucket_count];
     iter_mut!(final_eval, 1024).enumerate().for_each(|(i, b)| {
         iter_mut!(b, 1024).enumerate().for_each(|(j, f)| {
-            *f = E::default();
             let start = i * bucket_size + poly_count * j;
             evaluations[start..start + poly_count]
                 .iter()

--- a/src/frida_prover/traits.rs
+++ b/src/frida_prover/traits.rs
@@ -174,8 +174,8 @@ where
             let mut domain_size = self.domain_size();
             let folding_factor = self.options().folding_factor();
 
-            let start = if self.is_batch() { 1 } else { 0 };
-            if start == 1 {
+            
+            if self.is_batch() {
                 positions = fold_positions(&positions, domain_size, folding_factor);
                 let proof = self
                     .get_layer(0)
@@ -198,6 +198,7 @@ where
 
             // for all FRI layers, except the last one, record tree root, determine a set of query
             // positions, and query the layer at these positions.
+            let start = if self.is_batch() { 1 } else { 0 };
             for i in start..layers_len {
                 positions = fold_positions(&positions, domain_size, folding_factor);
 

--- a/src/frida_verifier/das.rs
+++ b/src/frida_verifier/das.rs
@@ -141,7 +141,7 @@ where
                 xi = Some(public_coin.draw_xi(poly_count)?)
             }
 
-            let alpha = public_coin.draw().map_err(|_e| FridaError::DrawError())?;
+            let alpha = public_coin.draw()?;
             layer_alphas.push(alpha);
 
             // make sure the degree can be reduced by the folding factor at all layers

--- a/src/frida_verifier/das.rs
+++ b/src/frida_verifier/das.rs
@@ -31,7 +31,7 @@ where
     layer_alphas: Vec<E>,
     options: FriOptions,
     num_partitions: usize,
-    batch_size: usize,
+    poly_count: usize,
     _public_coin: PhantomData<R>,
     _field_element: PhantomData<E>,
     _h_random: PhantomData<HRandom>,
@@ -60,9 +60,8 @@ where
             self.layer_commitments.clone(),
             self.domain_size,
             self.options.folding_factor(),
-            self.batch_size,
-        )
-        .map_err(|_e| FridaError::DeserializationError())?;
+            self.poly_count,
+        )?;
 
         self.check_auth(&mut verifier_channel, evaluations, positions)
             .map_err(|_e| FridaError::FailToVerify)
@@ -74,7 +73,7 @@ where
         folded_positions: &[usize],
         domain_size: usize,
     ) -> Vec<E> {
-        if verifier_channel.batch_size() > 0 {
+        if verifier_channel.poly_count() > 1 {
             let layer_values = verifier_channel
                 .batch_data
                 .as_ref()
@@ -88,7 +87,7 @@ where
                 positions,
                 folded_positions,
                 domain_size,
-                verifier_channel.batch_size(),
+                verifier_channel.poly_count(),
             )
         } else {
             let layer_values = group_slice_elements(&verifier_channel.layer_queries[0]);
@@ -122,32 +121,27 @@ where
     fn new(
         das_commitment: Commitment<HRandom>,
         public_coin: &mut R,
-        options: FriOptions
+        options: FriOptions,
     ) -> Result<Self, FridaError> {
         let domain_size = das_commitment.domain_size;
         let num_partitions = das_commitment.proof.num_partitions();
         let max_poly_degree = domain_size / options.blowup_factor() - 1;
 
         // read layer commitments from the channel and use them to build a list of alphas
-        let batch_size = das_commitment.batch_size;
+        let poly_count = das_commitment.poly_count;
         let layer_commitments = das_commitment.roots;
-        let mut alpha_commitments = &layer_commitments[..];
+        let alpha_commitments = &layer_commitments[..];
 
-        let xi = if batch_size > 0 {
-            alpha_commitments = &layer_commitments[1..];
-            let batch_layer_root = layer_commitments[0];
-            public_coin.reseed(&batch_layer_root.as_bytes());
-            Some(public_coin.draw_xi(batch_size)?)
-        } else {
-            None
-        };
-
+        let mut xi = None;
         let mut layer_alphas = Vec::with_capacity(alpha_commitments.len());
         let mut max_degree_plus_1 = max_poly_degree + 1;
         for (depth, commitment) in alpha_commitments.iter().enumerate() {
             public_coin.reseed(&commitment.as_bytes());
-            let alpha = public_coin.draw().map_err(|_e| FridaError::DrawError())?;
+            if depth == 0 && poly_count > 1 {
+                xi = Some(public_coin.draw_xi(poly_count)?)
+            }
 
+            let alpha = public_coin.draw().map_err(|_e| FridaError::DrawError())?;
             layer_alphas.push(alpha);
 
             // make sure the degree can be reduced by the folding factor at all layers
@@ -172,7 +166,7 @@ where
             layer_commitments.clone(),
             domain_size,
             options.folding_factor(),
-            batch_size,
+            poly_count,
         )
         .map_err(|_e| FridaError::InvalidDASCommitment)?;
 
@@ -217,7 +211,7 @@ where
             max_poly_degree,
             domain_size,
             num_partitions,
-            batch_size,
+            poly_count,
             layer_commitments,
             xi,
             layer_alphas,

--- a/src/frida_verifier/mod.rs
+++ b/src/frida_verifier/mod.rs
@@ -26,25 +26,23 @@ fn get_query_values<E: FieldElement, const N: usize>(
 }
 
 fn get_batch_query_values<E: FieldElement, const N: usize>(
-    values: &[Vec<E>],
+    values: &[E],
     positions: &[usize],
     folded_positions: &[usize],
     domain_size: usize,
-    batch_size: usize,
+    poly_count: usize,
 ) -> Vec<E> {
     let row_length = domain_size / N;
-    let mut result = Vec::with_capacity(batch_size * positions.len());
+    let mut result = Vec::with_capacity(poly_count * positions.len());
     for position in positions.iter() {
         let idx = folded_positions
             .iter()
             .position(|&v| v == position % row_length)
             .unwrap();
-        values[idx][(position / row_length) * batch_size
-            ..(position / row_length) * batch_size + batch_size]
-            .iter()
-            .for_each(|e| {
-                result.push(*e);
-            });
+        let start = idx * (poly_count * N) + (position / row_length) * poly_count;
+        values[start..start + poly_count].iter().for_each(|e| {
+            result.push(*e);
+        });
     }
     result
 }
@@ -101,16 +99,12 @@ mod tests {
             let (commitment, _) = prover.commit(data.clone(), 3).unwrap();
 
             let mut public_coin =
-                FridaRandom::<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>::new(&[
-                    123,
-                ]);
+                FridaRandom::<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>::new(
+                    &[123],
+                );
 
-            let verifier = FridaDasVerifier::new(
-                commitment,
-                &mut public_coin,
-                options.clone(),
-            )
-            .unwrap();
+            let verifier =
+                FridaDasVerifier::new(commitment, &mut public_coin, options.clone()).unwrap();
 
             // query for a position
             let open_position = [1];
@@ -124,7 +118,9 @@ mod tests {
                 .iter()
                 .map(|&p| evaluations[p])
                 .collect::<Vec<_>>();
-            verifier.verify(proof, &queried_evaluations, &open_position).unwrap();
+            verifier
+                .verify(proof, &queried_evaluations, &open_position)
+                .unwrap();
         }
     }
 
@@ -149,12 +145,8 @@ mod tests {
                 123,
             ]);
 
-        let verifier = FridaDasVerifier::new(
-            commitment,
-            &mut public_coin,
-            options.clone(),
-        )
-        .unwrap();
+        let verifier =
+            FridaDasVerifier::new(commitment, &mut public_coin, options.clone()).unwrap();
 
         // query for a position
         let open_position = [1];
@@ -168,6 +160,8 @@ mod tests {
             .iter()
             .map(|&p| evaluations[p])
             .collect::<Vec<_>>();
-        verifier.verify(proof, &queried_evaluations, &open_position).unwrap();
+        verifier
+            .verify(proof, &queried_evaluations, &open_position)
+            .unwrap();
     }
 }

--- a/src/frida_verifier/test.rs
+++ b/src/frida_verifier/test.rs
@@ -11,7 +11,7 @@ mod test {
     use crate::frida_verifier::traits::BaseFridaVerifier;
     use crate::utils::{build_evaluations, build_prover_channel};
     use winter_crypto::hashers::Blake3_256;
-    use winter_fri::folding::{self, fold_positions};
+    use winter_fri::folding::fold_positions;
     use winter_fri::{FriOptions, ProverChannel};
     use winter_math::fields::f128::BaseElement;
     use winter_rand_utils::{rand_value, rand_vector};

--- a/src/frida_verifier/test.rs
+++ b/src/frida_verifier/test.rs
@@ -17,6 +17,17 @@ mod test {
     use winter_rand_utils::{rand_value, rand_vector};
 
     type Blake3 = Blake3_256<BaseElement>;
+    type Prover = FridaProver<
+        BaseElement,
+        BaseElement,
+        FridaProverChannel<
+            BaseElement,
+            Blake3_256<BaseElement>,
+            Blake3_256<BaseElement>,
+            FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
+        >,
+        Blake3_256<BaseElement>,
+    >;
 
     #[test]
     fn test_drawn_alpha() {
@@ -115,17 +126,7 @@ mod test {
         let options = FriOptions::new(lde_blowup, folding_factor, max_remainder_degree);
 
         // instantiate the prover and generate the proof
-        let mut prover: FridaProver<
-            BaseElement,
-            BaseElement,
-            FridaProverChannel<
-                BaseElement,
-                Blake3_256<BaseElement>,
-                Blake3_256<BaseElement>,
-                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
-            >,
-            Blake3_256<BaseElement>,
-        > = FridaProver::new(options.clone());
+        let mut prover: Prover = FridaProver::new(options.clone());
         let poly_count = 10;
         let mut data = vec![];
         for _ in 0..poly_count {
@@ -222,17 +223,7 @@ mod test {
         let blowup_factor = 2;
         let folding_factor = 2;
         let options = FriOptions::new(blowup_factor, folding_factor, 0);
-        let mut prover: FridaProver<
-            BaseElement,
-            BaseElement,
-            FridaProverChannel<
-                BaseElement,
-                Blake3_256<BaseElement>,
-                Blake3_256<BaseElement>,
-                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
-            >,
-            Blake3_256<BaseElement>,
-        > = FridaProver::new(options.clone());
+        let mut prover: Prover = FridaProver::new(options.clone());
 
         let (commitment, _) = prover.commit_batch(data, 4).unwrap();
         let proof = commitment.proof.clone();
@@ -257,17 +248,7 @@ mod test {
         let blowup_factor = 2;
         let folding_factor = 4;
         let options = FriOptions::new(blowup_factor, folding_factor, 0);
-        let mut prover: FridaProver<
-            BaseElement,
-            BaseElement,
-            FridaProverChannel<
-                BaseElement,
-                Blake3_256<BaseElement>,
-                Blake3_256<BaseElement>,
-                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
-            >,
-            Blake3_256<BaseElement>,
-        > = FridaProver::new(options.clone());
+        let mut prover: Prover = FridaProver::new(options.clone());
 
         let (commitment, _) = prover.commit_batch(data, 4).unwrap();
         let proof = commitment.proof.clone();

--- a/src/frida_verifier/test.rs
+++ b/src/frida_verifier/test.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod test {
+    use crate::frida_prover::proof::FridaProof;
     use crate::frida_prover::traits::BaseFriProver;
     use crate::frida_prover::{Commitment, FridaProver};
     use crate::frida_prover_channel::{
@@ -10,8 +11,8 @@ mod test {
     use crate::frida_verifier::traits::BaseFridaVerifier;
     use crate::utils::{build_evaluations, build_prover_channel};
     use winter_crypto::hashers::Blake3_256;
-    use winter_fri::folding::fold_positions;
-    use winter_fri::FriOptions;
+    use winter_fri::folding::{self, fold_positions};
+    use winter_fri::{FriOptions, ProverChannel};
     use winter_math::fields::f128::BaseElement;
     use winter_rand_utils::{rand_value, rand_vector};
 
@@ -49,7 +50,7 @@ mod test {
                 roots,
                 domain_size,
                 num_queries: 32,
-                batch_size: 0,
+                poly_count: 1,
             },
             &mut coin,
             options.clone(),
@@ -57,14 +58,161 @@ mod test {
         .unwrap();
 
         let layer_alpha = verifier.layer_alphas();
-        assert_eq!(prover_drawn_alpha, layer_alpha[..layer_alpha.len() - 1])
+        assert_eq!(prover_drawn_alpha, layer_alpha[..layer_alpha.len() - 1]);
+
+        prover.reset();
+        let poly_count = 10;
+        let mut data = vec![];
+        for _ in 0..poly_count {
+            data.push(rand_vector::<u8>(usize::min(
+                rand_value::<u64>() as usize,
+                128,
+            )));
+        }
+        let (commitment, _) = prover.commit_batch(data, 32).unwrap();
+        let mut channel = FridaProverChannel::<
+            BaseElement,
+            Blake3_256<BaseElement>,
+            Blake3_256<BaseElement>,
+            FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
+        >::new(prover.domain_size(), 32);
+        for layer_root in commitment.roots.iter() {
+            channel.commit_fri_layer(*layer_root);
+            channel.draw_fri_alpha();
+        }
+        let prover_drawn_alpha = channel.drawn_alphas();
+        let roots = channel.layer_commitments().to_vec();
+        let positions = channel.draw_query_positions();
+        let proof = prover.build_proof(&positions);
+
+        let mut coin = FridaRandom::<Blake3, Blake3, BaseElement>::new(&[123]);
+        let verifier = FridaDasVerifier::new(
+            Commitment {
+                proof,
+                roots,
+                domain_size: prover.domain_size(),
+                num_queries: 32,
+                poly_count: 10,
+            },
+            &mut coin,
+            options.clone(),
+        )
+        .unwrap();
+        let layer_alpha = verifier.layer_alphas();
+        assert_eq!(
+            prover_drawn_alpha[..prover_drawn_alpha.len() - 1],
+            layer_alpha[..layer_alpha.len() - 1]
+        )
+    }
+
+    #[test]
+    fn test_drawn_alpha_batch() {
+        let lde_blowup_e = 3;
+        let folding_factor_e = 1;
+        let max_remainder_degree = 7;
+        let lde_blowup = 1 << lde_blowup_e;
+        let folding_factor = 1 << folding_factor_e;
+        let options = FriOptions::new(lde_blowup, folding_factor, max_remainder_degree);
+
+        // instantiate the prover and generate the proof
+        let mut prover: FridaProver<
+            BaseElement,
+            BaseElement,
+            FridaProverChannel<
+                BaseElement,
+                Blake3_256<BaseElement>,
+                Blake3_256<BaseElement>,
+                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
+            >,
+            Blake3_256<BaseElement>,
+        > = FridaProver::new(options.clone());
+        let poly_count = 10;
+        let mut data = vec![];
+        for _ in 0..poly_count {
+            data.push(rand_vector::<u8>(usize::min(
+                rand_value::<u64>() as usize,
+                128,
+            )));
+        }
+        let (commitment, _) = prover.commit_batch(data, 32).unwrap();
+        let mut channel = FridaProverChannel::<
+            BaseElement,
+            Blake3_256<BaseElement>,
+            Blake3_256<BaseElement>,
+            FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
+        >::new(prover.domain_size(), 32);
+        for layer_root in commitment.roots.iter() {
+            channel.commit_fri_layer(*layer_root);
+            channel.draw_fri_alpha();
+        }
+        let prover_drawn_alpha = channel.drawn_alphas();
+        let roots = channel.layer_commitments().to_vec();
+        let positions = channel.draw_query_positions();
+        let proof = prover.build_proof(&positions);
+
+        let mut coin = FridaRandom::<Blake3, Blake3, BaseElement>::new(&[123]);
+        let verifier = FridaDasVerifier::new(
+            Commitment {
+                proof,
+                roots,
+                domain_size: prover.domain_size(),
+                num_queries: 32,
+                poly_count: 10,
+            },
+            &mut coin,
+            options.clone(),
+        )
+        .unwrap();
+        let layer_alpha = verifier.layer_alphas();
+        assert_eq!(
+            prover_drawn_alpha[..prover_drawn_alpha.len() - 1],
+            layer_alpha[..layer_alpha.len() - 1]
+        )
+    }
+
+    fn verify_batch(
+        data_evaluations: &Vec<BaseElement>,
+        proof: FridaProof,
+        commitment: Commitment<Blake3_256<BaseElement>>,
+        options: FriOptions,
+        domain_size: usize,
+    ) {
+        let poly_count = commitment.poly_count;
+        let folding_factor = options.folding_factor();
+
+        let mut coin =
+            FridaRandom::<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>::new(&[
+                123,
+            ]);
+
+        let verifier = FridaDasVerifier::new(commitment, &mut coin, options.clone()).unwrap();
+
+        let mut query_positions = coin.draw_query_positions(4, domain_size).unwrap();
+        query_positions.dedup();
+        query_positions = fold_positions(&query_positions, domain_size, folding_factor);
+
+        let mut evaluations = vec![];
+        for position in query_positions.iter() {
+            let bucket = position % (domain_size / folding_factor);
+            let start_index = (position / (domain_size / folding_factor)) * poly_count;
+            data_evaluations[bucket * poly_count * folding_factor + start_index
+                ..bucket * poly_count * folding_factor + start_index + poly_count]
+                .iter()
+                .for_each(|e| {
+                    evaluations.push(*e);
+                });
+        }
+
+        verifier
+            .verify(proof, &evaluations, &query_positions)
+            .unwrap();
     }
 
     #[test]
     fn test_verify_batch() {
-        let batch_size = 10;
+        let poly_count = 10;
         let mut data = vec![];
-        for _ in 0..batch_size {
+        for _ in 0..poly_count {
             data.push(rand_vector::<u8>(usize::min(
                 rand_value::<u64>() as usize,
                 128,
@@ -89,36 +237,47 @@ mod test {
         let (commitment, _) = prover.commit_batch(data, 4).unwrap();
         let proof = commitment.proof.clone();
 
-        let mut coin =
-            FridaRandom::<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>::new(&[
-                123,
-            ]);
-
-        let verifier = FridaDasVerifier::new(
+        verify_batch(
+            &prover.get_layer(0).evaluations,
+            proof,
             commitment,
-            &mut coin,
-            options.clone(),
-        )
-        .unwrap();
+            options,
+            prover.domain_size(),
+        );
+    }
 
-        let mut query_positions = coin.draw_query_positions(4, prover.domain_size()).unwrap();
-        query_positions.dedup();
-        query_positions = fold_positions(&query_positions, prover.domain_size(), folding_factor);
-
-        let mut evaluations = vec![];
-        for position in query_positions.iter() {
-            let bucket = position % (prover.domain_size() / folding_factor);
-            let start_index = (position / (prover.domain_size() / folding_factor)) * batch_size;
-            prover.get_batch_layer().as_ref().unwrap().evaluations[bucket]
-                [start_index..start_index + batch_size]
-                .iter()
-                .for_each(|e| {
-                    evaluations.push(*e);
-                });
+    #[test]
+    fn test_batching_only_batch_layer() {
+        let poly_count = 10;
+        let mut data = vec![];
+        for _ in 0..poly_count {
+            data.push(rand_vector::<u8>(1));
         }
 
-        verifier
-            .verify(proof, &evaluations, &query_positions)
-            .unwrap();
+        let blowup_factor = 2;
+        let folding_factor = 4;
+        let options = FriOptions::new(blowup_factor, folding_factor, 0);
+        let mut prover: FridaProver<
+            BaseElement,
+            BaseElement,
+            FridaProverChannel<
+                BaseElement,
+                Blake3_256<BaseElement>,
+                Blake3_256<BaseElement>,
+                FridaRandom<Blake3_256<BaseElement>, Blake3_256<BaseElement>, BaseElement>,
+            >,
+            Blake3_256<BaseElement>,
+        > = FridaProver::new(options.clone());
+
+        let (commitment, _) = prover.commit_batch(data, 4).unwrap();
+        let proof = commitment.proof.clone();
+
+        verify_batch(
+            &prover.get_layer(0).evaluations,
+            proof,
+            commitment,
+            options,
+            prover.domain_size(),
+        );
     }
 }

--- a/src/frida_verifier/test.rs
+++ b/src/frida_verifier/test.rs
@@ -47,7 +47,7 @@ mod test {
 
         // instantiate the prover and generate the proof
         let mut prover = FridaProver::new(options.clone());
-        prover.build_layers(&mut channel, evaluations.clone());
+        prover.build_layers(&mut channel, evaluations.clone(), false);
         let prover_drawn_alpha = channel.drawn_alphas();
         let roots = channel.layer_commitments().to_vec();
 

--- a/src/frida_verifier/traits.rs
+++ b/src/frida_verifier/traits.rs
@@ -6,9 +6,9 @@ use winter_fri::{
 };
 use winter_math::{polynom, FieldElement};
 
+use winter_utils::iter_mut;
 #[cfg(feature = "concurrent")]
 use winter_utils::iterators::*;
-use winter_utils::{iter_mut, uninit_vector};
 
 use crate::{
     frida_error::FridaError, frida_prover::Commitment, frida_random::FridaRandomCoin,
@@ -110,12 +110,11 @@ where
                 let layer_values =
                     channel.read_batch_layer_queries(&position_indexes, &layer_commitment)?;
                 let mut combined_layer_values: Vec<[E; N]> =
-                    unsafe { uninit_vector(layer_values.len() / poly_count / N) };
+                    vec![[E::default(); N]; layer_values.len() / poly_count / N];
                 iter_mut!(combined_layer_values, 1024)
                     .enumerate()
                     .for_each(|(i, b)| {
                         iter_mut!(b, 1024).enumerate().for_each(|(j, f)| {
-                            *f = E::default();
                             let start = i * (poly_count * N) + poly_count * j;
                             layer_values[start..start + poly_count]
                                 .iter()
@@ -126,9 +125,8 @@ where
                         });
                     });
 
-                let mut new_eval = unsafe { uninit_vector(evaluations.len() / poly_count) };
+                let mut new_eval = vec![E::default(); evaluations.len() / poly_count];
                 iter_mut!(new_eval, 1024).enumerate().for_each(|(i, f)| {
-                    *f = E::default();
                     evaluations[i * poly_count..i * poly_count + poly_count]
                         .iter()
                         .enumerate()

--- a/src/frida_verifier/traits.rs
+++ b/src/frida_verifier/traits.rs
@@ -15,7 +15,7 @@ use crate::{
     frida_verifier_channel::BaseVerifierChannel,
 };
 
-use super::{eval_horner, get_batch_query_values};
+use super::eval_horner;
 
 pub trait BaseFridaVerifier<E, HHst, HRandom, R>
 where
@@ -47,7 +47,7 @@ where
         evaluations: &[E],
         positions: &[usize],
     ) -> Result<(), VerifierError> {
-        if evaluations.len() != positions.len() * usize::max(channel.batch_size(), 1) {
+        if evaluations.len() != positions.len() * channel.poly_count() {
             return Err(VerifierError::NumPositionEvaluationMismatch(
                 positions.len(),
                 evaluations.len(),
@@ -76,6 +76,7 @@ where
     ) -> Result<(), VerifierError> {
         let options = self.options();
         let original_domain_size = self.domain_size();
+        let poly_count = channel.poly_count();
         let mut domain_generator = self.domain_generator();
 
         // pre-compute roots of unity used in computing x coordinates in the folded domain
@@ -87,13 +88,7 @@ where
         let mut domain_size = original_domain_size;
         let mut max_degree_plus_1 = self.max_poly_degree() + 1;
         let mut positions = positions.to_vec();
-        let mut layer_index_modifier = 0;
-        let mut evaluations = if channel.batch_size() > 0 {
-            layer_index_modifier = 1;
-            self.verify_batch_layer::<C, N>(channel, evaluations, &positions)?
-        } else {
-            evaluations.to_vec()
-        };
+        let mut evaluations = evaluations.to_vec();
 
         let num_fri_layers = options.num_fri_layers(original_domain_size);
         for depth in 0..num_fri_layers {
@@ -108,9 +103,44 @@ where
                 self.num_partitions(),
             );
             // read query values from the specified indexes in the Merkle tree
-            let layer_commitment = self.get_layer_commitment(depth + layer_index_modifier);
+            let layer_commitment = self.get_layer_commitment(depth);
             // TODO: add layer depth to the potential error message
-            let layer_values = channel.read_layer_queries(&position_indexes, &layer_commitment)?;
+            let layer_values = if poly_count > 1 && depth == 0 {
+                let xi = self.xi().unwrap();
+                let layer_values =
+                    channel.read_batch_layer_queries(&position_indexes, &layer_commitment)?;
+                let mut combined_layer_values: Vec<[E; N]> =
+                    unsafe { uninit_vector(layer_values.len() / poly_count / N) };
+                iter_mut!(combined_layer_values, 1024)
+                    .enumerate()
+                    .for_each(|(i, b)| {
+                        iter_mut!(b, 1024).enumerate().for_each(|(j, f)| {
+                            *f = E::default();
+                            let start = i * (poly_count * N) + poly_count * j;
+                            layer_values[start..start + poly_count]
+                                .iter()
+                                .enumerate()
+                                .for_each(|(j, e)| {
+                                    *f += *e * xi[j];
+                                });
+                        });
+                    });
+
+                let mut new_eval = unsafe { uninit_vector(evaluations.len() / poly_count) };
+                iter_mut!(new_eval, 1024).enumerate().for_each(|(i, f)| {
+                    *f = E::default();
+                    evaluations[i * poly_count..i * poly_count + poly_count]
+                        .iter()
+                        .enumerate()
+                        .for_each(|(j, e)| {
+                            *f += *e * xi[j];
+                        });
+                });
+                evaluations = new_eval;
+                combined_layer_values
+            } else {
+                channel.read_layer_queries(&position_indexes, &layer_commitment)?
+            };
             let query_values =
                 get_query_values::<E, N>(&layer_values, &positions, &folded_positions, domain_size);
             if evaluations != query_values {
@@ -176,52 +206,6 @@ where
         }
 
         Ok(())
-    }
-
-    fn verify_batch_layer<C: BaseVerifierChannel<E, Hasher = HRandom>, const N: usize>(
-        &self,
-        channel: &mut C,
-        evaluations: &[E],
-        positions: &[usize],
-    ) -> Result<Vec<E>, VerifierError> {
-        let options = self.options();
-        let domain_size = self.domain_size();
-
-        // determine which evaluations were queried in the folded layer
-        let folded_positions = fold_positions(positions, domain_size, options.folding_factor());
-        // determine where these evaluations are in the commitment Merkle tree
-        let position_indexes = map_positions_to_indexes(
-            &folded_positions,
-            domain_size,
-            options.folding_factor(),
-            self.num_partitions(),
-        );
-
-        let batch_size = channel.batch_size();
-        let layer_values = channel.read_batch_layer_queries(&position_indexes)?;
-        let query_values = get_batch_query_values::<E, N>(
-            &layer_values,
-            positions,
-            &folded_positions,
-            domain_size,
-            batch_size,
-        );
-        if evaluations != query_values {
-            return Err(VerifierError::InvalidLayerFolding(0));
-        }
-
-        let xi = self.xi().unwrap();
-        let mut next_eval = unsafe { uninit_vector(query_values.len() / batch_size) };
-        iter_mut!(next_eval, 1024).enumerate().for_each(|(i, f)| {
-            *f = E::default();
-            query_values[i * batch_size..i * batch_size + batch_size]
-                .iter()
-                .enumerate()
-                .for_each(|(j, e)| {
-                    *f += *e * xi[j];
-                });
-        });
-        Ok(next_eval)
     }
 }
 

--- a/src/frida_verifier_channel.rs
+++ b/src/frida_verifier_channel.rs
@@ -1,23 +1,21 @@
 use winter_crypto::{BatchMerkleProof, ElementHasher, Hasher, MerkleTree};
 use winter_fri::{VerifierChannel, VerifierError};
 use winter_math::FieldElement;
-use winter_utils::DeserializationError;
 
-use crate::frida_prover::proof::FridaProof;
+use crate::{frida_error::FridaError, frida_prover::proof::FridaProof};
 
 pub struct FridaVerifierChannel<E: FieldElement, H: ElementHasher<BaseField = E::BaseField>> {
     layer_commitments: Vec<H::Digest>,
-    batch_size: usize,
-    pub(crate) batch_data: Option<BatchData<E, H>>,
+    poly_count: usize,
     layer_proofs: Vec<BatchMerkleProof<H>>,
+    pub(crate) batch_data: Option<BatchData<E, H>>,
     pub(crate) layer_queries: Vec<Vec<E>>,
     remainder: Vec<E>,
     num_partitions: usize,
 }
 
 pub struct BatchData<E: FieldElement, H: ElementHasher<BaseField = E::BaseField>> {
-    batch_commitment: Option<H::Digest>,
-    pub(crate) batch_layer_queries: Option<Vec<Vec<E>>>,
+    pub(crate) batch_layer_queries: Option<Vec<E>>,
     batch_layer_proof: Option<BatchMerkleProof<H>>,
 }
 
@@ -28,34 +26,41 @@ where
 {
     pub fn new(
         mut proof: FridaProof,
-        mut layer_commitments: Vec<H::Digest>,
-        domain_size: usize,
+        layer_commitments: Vec<H::Digest>,
+        mut domain_size: usize,
         folding_factor: usize,
-        batch_size: usize,
-    ) -> Result<Self, DeserializationError> {
+        poly_count: usize,
+    ) -> Result<Self, FridaError> {
+        assert!(poly_count != 0, "poly_count must be greater than 0");
+
         let num_partitions = proof.num_partitions();
 
-        let remainder = proof.parse_remainder()?;
+        let remainder = proof
+            .parse_remainder()
+            .map_err(|e| FridaError::DeserializationError(e))?;
 
-        let batch_data = if batch_size != 0 {
-            let (batch_layer_queries, batch_layer_proof) =
-                proof.parse_batch_layer::<H, E>(domain_size, folding_factor, batch_size)?;
-            let batch_commitment = layer_commitments.remove(0);
+        let batch_data = if poly_count > 1 {
+            let (batch_layer_queries, batch_layer_proof) = proof
+                .parse_batch_layer::<H, E>(domain_size, folding_factor, poly_count)
+                .map_err(|e| FridaError::DeserializationError(e))?;
+            domain_size /= folding_factor;
             Some(BatchData {
-                batch_commitment: Some(batch_commitment),
                 batch_layer_queries: Some(batch_layer_queries),
                 batch_layer_proof: Some(batch_layer_proof),
             })
         } else {
+            if proof.batch_layer.is_some() {
+                return Err(FridaError::ProofPolyCountMismatch());
+            }
             None
         };
 
-        let (layer_queries, layer_proofs) =
-            proof.parse_layers::<H, E>(domain_size, folding_factor)?;
-
+        let (layer_queries, layer_proofs) = proof
+            .parse_layers::<H, E>(domain_size, folding_factor)
+            .map_err(|e| FridaError::DeserializationError(e))?;
         Ok(Self {
             layer_commitments,
-            batch_size,
+            poly_count,
             batch_data,
             layer_proofs,
             layer_queries,
@@ -97,12 +102,12 @@ pub trait BaseVerifierChannel<E>: VerifierChannel<E>
 where
     E: FieldElement,
 {
-    fn batch_size(&self) -> usize;
-    fn batch_layer_commitment(&self) -> &<<Self as VerifierChannel<E>>::Hasher as Hasher>::Digest;
+    fn poly_count(&self) -> usize;
     fn read_batch_layer_queries(
         &mut self,
         positions: &[usize],
-    ) -> Result<Vec<Vec<E>>, VerifierError>;
+        commitment: &<<Self as VerifierChannel<E>>::Hasher as Hasher>::Digest,
+    ) -> Result<Vec<E>, VerifierError>;
 }
 
 impl<E, H> BaseVerifierChannel<E> for FridaVerifierChannel<E, H>
@@ -110,25 +115,17 @@ where
     E: FieldElement,
     H: ElementHasher<BaseField = E::BaseField>,
 {
-    fn batch_size(&self) -> usize {
-        self.batch_size
-    }
-    fn batch_layer_commitment(&self) -> &<<Self as VerifierChannel<E>>::Hasher as Hasher>::Digest {
-        self.batch_data
-            .as_ref()
-            .unwrap()
-            .batch_commitment
-            .as_ref()
-            .unwrap()
+    fn poly_count(&self) -> usize {
+        self.poly_count
     }
     fn read_batch_layer_queries(
         &mut self,
         positions: &[usize],
-    ) -> Result<Vec<Vec<E>>, VerifierError> {
+        commitment: &<<Self as VerifierChannel<E>>::Hasher as Hasher>::Digest,
+    ) -> Result<Vec<E>, VerifierError> {
         let mut batch_data = self.batch_data.take().unwrap();
         let layer_proof = batch_data.batch_layer_proof.take().unwrap();
-        let commitment = batch_data.batch_commitment.take().unwrap();
-        MerkleTree::<Self::Hasher>::verify_batch(&commitment, positions, &layer_proof)
+        MerkleTree::<Self::Hasher>::verify_batch(commitment, positions, &layer_proof)
             .map_err(|_| VerifierError::LayerCommitmentMismatch)?;
         let layer_queries = batch_data.batch_layer_queries.take().unwrap();
         Ok(layer_queries)

--- a/src/frida_verifier_channel.rs
+++ b/src/frida_verifier_channel.rs
@@ -27,12 +27,13 @@ where
     pub fn new(
         mut proof: FridaProof,
         layer_commitments: Vec<H::Digest>,
-        mut domain_size: usize,
+        domain_size: usize,
         folding_factor: usize,
         poly_count: usize,
     ) -> Result<Self, FridaError> {
         assert!(poly_count != 0, "poly_count must be greater than 0");
 
+        let mut domain_size = domain_size;
         let num_partitions = proof.num_partitions();
 
         let remainder = proof
@@ -49,8 +50,8 @@ where
                 batch_layer_proof: Some(batch_layer_proof),
             })
         } else {
-            if proof.batch_layer.is_some() {
-                return Err(FridaError::ProofPolyCountMismatch());
+            if proof.has_batch_layer() {
+                return Err(FridaError::ProofPolyCountMismatch);
             }
             None
         };

--- a/src/frida_verifier_channel.rs
+++ b/src/frida_verifier_channel.rs
@@ -37,12 +37,12 @@ where
 
         let remainder = proof
             .parse_remainder()
-            .map_err(|e| FridaError::DeserializationError(e))?;
+            .map_err(FridaError::DeserializationError)?;
 
         let batch_data = if poly_count > 1 {
             let (batch_layer_queries, batch_layer_proof) = proof
                 .parse_batch_layer::<H, E>(domain_size, folding_factor, poly_count)
-                .map_err(|e| FridaError::DeserializationError(e))?;
+                .map_err(FridaError::DeserializationError)?;
             domain_size /= folding_factor;
             Some(BatchData {
                 batch_layer_queries: Some(batch_layer_queries),
@@ -57,7 +57,7 @@ where
 
         let (layer_queries, layer_proofs) = proof
             .parse_layers::<H, E>(domain_size, folding_factor)
-            .map_err(|e| FridaError::DeserializationError(e))?;
+            .map_err(FridaError::DeserializationError)?;
         Ok(Self {
             layer_commitments,
             poly_count,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
                     proof,
                     domain_size,
                     num_queries: 32,
-                    batch_size: 0,
+                    poly_count: 1,
                 },
                 &mut coin,
                 options.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ mod tests {
 
             // instantiate the prover and generate the proof
             let mut prover = FridaProver::new(options.clone());
-            prover.build_layers(&mut channel, evaluations.clone());
+            prover.build_layers(&mut channel, evaluations.clone(), false);
 
             let positions = channel.draw_query_positions();
             let proof = prover.build_proof(&positions);


### PR DESCRIPTION
In our previous implementation for batched fri these were the steps we took
- Create a merkle tree where the leaf nodes correspond to
```
leaf0: [G1(w0), G2(w0), G3(w0)]
leaf1: [G1(w1), G2(w1), G3(w1)]
leaf2: [G1(w2), G2(w2), G3(w2)]
leaf3: [G1(w3), G2(w3), G3(w3)]
```
- Calculate $G0 = \xi_0G1 + \xi_1G2 + \xi_2G3$
- Create merkle tree for G0
- Calculate G0_fold
- Create merkle tree for G0_fold
- ...

And when creating proofs not only do we create merkle proofs for all the G0, G0_fold, ... trees we also create a proof for the batch layer's tree so we can reveal G1, G2, G3

But considering the fact that $G0 = \xi_0G1 + \xi_1G2 + \xi_2G3$ we can just skip creating the merkle tree for G0 (and also reduce the need for the merkle proof for that tree) and use the batch layer's merkle tree directly as the first FRI layer's merkle tree
- Create a merkle tree where the leaf nodes correspond to
```
leaf0: [G1(w0), G2(w0), G3(w0)]
leaf1: [G1(w1), G2(w1), G3(w1)]
leaf2: [G1(w2), G2(w2), G3(w2)]
leaf3: [G1(w3), G2(w3), G3(w3)]
```
- Calculate $G0 = \xi_0G1 + \xi_1G2 + \xi_2G3$
- Calculate G0_fold
- Create merkle tree for G0_fold
- ...